### PR TITLE
Bugfix: JS if-statement: failure when testing text with eq + not

### DIFF
--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/ConditionalStringEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/ConditionalStringEventHandler.java
@@ -1,0 +1,27 @@
+package com.sample.medusa.eventhandler.integrationtests.bug;
+
+import io.getmedusa.medusa.core.annotation.PageAttributes;
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.injector.DOMChanges;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+@UIEventPage(path = "/test/bug/conditional/string", file = "pages/integration-tests/bug/conditional-string")
+public class ConditionalStringEventHandler {
+
+    public PageAttributes setupAttributes(ServerRequest request) {
+        return new PageAttributes()
+                .with("word", "");
+    }
+
+    public DOMChanges hello() {
+        return DOMChanges.of("word", "Hello");
+    }
+
+    public DOMChanges world() {
+        return DOMChanges.of("word", "World");
+    }
+
+    public DOMChanges empty() {
+        return DOMChanges.of("word", "");
+    }
+}

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/conditional-string.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/conditional-string.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:m="https://getmedusa.io" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://getmedusa.io https://raw.githubusercontent.com/medusa-ui/medusa/main/medusa-ui.xsd">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello World</title>
+    <link href="/stylesheet.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+</head>
+<body>
+<h1>🦑 Medusa in trouble with "<m:text item="word"/>"</h1>
+    <m:if item="word" not="''">
+        <p>
+            word is <m:text item="word"/>.
+        </p>
+        <m:else>
+            <p>
+                word is empty.
+            </p>
+        </m:else>
+    </m:if>
+
+    <m:if item="word" eq="'Hello'">
+        <p class="hello-result">"<m:text item="word"/>" == "Hello"</p>
+        <m:else>
+            <p class="hello-result">"<m:text item="word"/>" != "Hello"</p>
+        </m:else>
+    </m:if>
+    <m:if item="word" eq='"World"'>
+        <p class="world-result">"<m:text item="word"/>" == "World"</p>
+        <m:else>
+            <p class="world-result">"<m:text item="word"/>" != "World"</p>
+        </m:else>
+    </m:if>
+    <button id="world_btn" m:click="world()">World</button>
+    <button id="hello_btn" m:click="hello()">Hello</button>
+    <button id="empty_btn" m:click="empty()">Empty</button>
+</body>
+</html>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/conditional-string.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/conditional-string.html
@@ -12,11 +12,11 @@
 <body>
 <h1>🦑 Medusa in trouble with "<m:text item="word"/>"</h1>
     <m:if item="word" not="''">
-        <p>
+        <p class="empty-result">
             word is <m:text item="word"/>.
         </p>
         <m:else>
-            <p>
+            <p class="empty-result">
                 word is empty.
             </p>
         </m:else>

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ConditionalStringIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ConditionalStringIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.sample.medusa.bug;
+
+import com.sample.medusa.meta.AbstractSeleniumTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ConditionalStringIntegrationTest extends AbstractSeleniumTest {
+
+    @Test
+    public void testWordsEqualTo(){
+        // initial value
+        goTo("/test/bug/conditional/string");
+        Assertions.assertTrue(driver.getPageSource().contains("Medusa in trouble"));
+        Assertions.assertEquals("", getFromValue("word"));
+        Assertions.assertEquals("word is empty.", getTextByClass("empty-result"));
+        Assertions.assertEquals("\"\" != \"Hello\"", getTextByClass("hello-result"));
+
+        // say Hello
+        clickById("hello_btn");
+        Assertions.assertEquals("Hello", getFromValue("word"));
+        Assertions.assertEquals("word is Hello.", getTextByClass("empty-result"));
+        Assertions.assertEquals("\"Hello\" == \"Hello\"", getTextByClass("hello-result"));
+        Assertions.assertEquals("\"Hello\" != \"World\"", getTextByClass("world-result"));
+
+        // say World
+        clickById("world_btn");
+        Assertions.assertEquals("World", getFromValue("word"));
+        Assertions.assertEquals("word is World.", getTextByClass("empty-result"));
+        Assertions.assertEquals("\"World\" != \"Hello\"", getTextByClass("hello-result"));
+        Assertions.assertEquals("\"World\" == \"World\"", getTextByClass("world-result"));
+
+        // clear
+        clickById("empty_btn");
+        Assertions.assertEquals("", getFromValue("word"));
+        Assertions.assertEquals("word is empty.", getTextByClass("empty-result"));
+        Assertions.assertEquals("\"\" != \"Hello\"", getTextByClass("hello-result"));
+        Assertions.assertEquals("\"\" != \"World\"", getTextByClass("world-result"));
+    }
+
+}
+
+

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/meta/VisibilityDetermination.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/meta/VisibilityDetermination.java
@@ -81,7 +81,9 @@ public class VisibilityDetermination extends AbstractTag {
 
     private String wrapped(Object item) {
         if(null == item) return "''";
-        if(!item.toString().startsWith("'")) return "'" + item + "'";
+        if(!item.toString().startsWith("'")) {
+            return "'" + item + "'";
+        }
         return item.toString();
     }
 

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/ExpressionEval.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/ExpressionEval.java
@@ -43,17 +43,19 @@ public abstract class ExpressionEval {
     }
 
     public static Object evalItemAsObj(String itemToEval, Map<String, Object> variables) {
-        if(isQuoted(itemToEval)) return unwrapQuotes(itemToEval);
+        if(isQuoted(itemToEval)) {
+            return itemToEval; //unwrapQuotes(itemToEval);
+        }
         return interpretValue(itemToEval, variables);
     }
 
-    private static String unwrapQuotes(String itemToEval) {
-        try {
-            return itemToEval.substring(1, itemToEval.length() - 1);
-        } catch (Exception e) {
-            return itemToEval;
-        }
-    }
+//    private static String unwrapQuotes(String itemToEval) {
+//        try {
+//            return itemToEval.substring(1, itemToEval.length() - 1);
+//        } catch (Exception e) {
+//            return itemToEval;
+//        }
+//    }
 
     public static boolean isQuoted(String itemToEval) {
         return (itemToEval.startsWith("'") && itemToEval.endsWith("'")) || (itemToEval.startsWith("\"") && itemToEval.endsWith("\""));

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/ExpressionEval.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/ExpressionEval.java
@@ -44,18 +44,10 @@ public abstract class ExpressionEval {
 
     public static Object evalItemAsObj(String itemToEval, Map<String, Object> variables) {
         if(isQuoted(itemToEval)) {
-            return itemToEval; //unwrapQuotes(itemToEval);
+            return itemToEval;
         }
         return interpretValue(itemToEval, variables);
     }
-
-//    private static String unwrapQuotes(String itemToEval) {
-//        try {
-//            return itemToEval.substring(1, itemToEval.length() - 1);
-//        } catch (Exception e) {
-//            return itemToEval;
-//        }
-//    }
 
     public static boolean isQuoted(String itemToEval) {
         return (itemToEval.startsWith("'") && itemToEval.endsWith("'")) || (itemToEval.startsWith("\"") && itemToEval.endsWith("\""));

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -150,6 +150,8 @@ _M.injectVariablesIntoConditionalExpression = function(expression, elem) {
                 //no action
             } else if(typeof varValue === "object") {
                 expression = expression.replaceAll(toReplace, JSON.stringify(varValue));
+            } else if(typeof varValue === "string") {
+                expression = expression.replaceAll( toReplace , "'" + varValue + "'");
             } else {
                 expression = expression.replaceAll(toReplace, varValue);
             }
@@ -585,6 +587,7 @@ _M.handleConditionalClass = function(k) {
 };
 
 _M.evalCondition = function(condition){
+    _M.debug("Evaluating condition: " , condition);
     return Function('"use strict";return (' + condition + ')')();
 };
 


### PR DESCRIPTION
Allows testing word against an actual value like: `<m:if item="word" eq="'Hello'">`

fixes #126 
Integration-test included