### PR TITLE
Namespace free tag detection

### DIFF
--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventController.java
@@ -118,6 +118,7 @@ public class UIEventController implements UIEventWithAttributes {
     private Method determineSetupMethod(Object uiEventPageObject, UIEventPage uiEventPage) {
         String setupMethodName = uiEventPage.setup();
         for(Method method :  uiEventPageObject.getClass().getMethods()) {
+            method.setAccessible(true);
             if (method.getName().equals(setupMethodName)) {
                 if (!returningPageAttributes(method)) {
                     throw new RuntimeException(uiEventPageObject.getClass().getName() + "." + method.getName() + " should return PageAttributes but was " + method.getReturnType());

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/ConditionalTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/ConditionalTag.java
@@ -19,8 +19,8 @@ public class ConditionalTag extends AbstractTag {
 
     @Override
     public InjectionResult inject(InjectionResult result, Map<String, Object> variables, ServerRequest request) {
-        Elements conditionalElements = result.getDocument().getElementsByTag(TagConstants.CONDITIONAL_TAG);
-        conditionalElements.sort(Comparator.comparingInt(o -> o.getElementsByTag(TagConstants.CONDITIONAL_TAG).size()));
+        Elements conditionalElements = result.getDocument().select(TagConstants.CONDITIONAL_TAG);
+        conditionalElements.sort(Comparator.comparingInt(o -> o.select(TagConstants.CONDITIONAL_TAG).size()));
         for(Element conditionalElement : conditionalElements) {
             handleIfElement(variables, conditionalElement, request);
         }
@@ -100,7 +100,7 @@ public class ConditionalTag extends AbstractTag {
     }
 
     private List<ElseIfElement> getElseIfElements(Element conditionalElement, Map<String, Object> variables, ServerRequest request, String mainCondition) {
-        final Elements elements = conditionalElement.getElementsByTag(TagConstants.M_ELSEIF);
+        final Elements elements = conditionalElement.select(TagConstants.M_ELSEIF);
         if(elements.isEmpty()) return Collections.emptyList();
         return elements.stream().map(e -> new ElseIfElement(e, variables, request, mainCondition)).toList();
     }
@@ -131,7 +131,7 @@ public class ConditionalTag extends AbstractTag {
     }
 
     private Element getElseElement(Element conditionalElement) {
-        final Elements elements = conditionalElement.getElementsByTag(TagConstants.M_ELSE);
+        final Elements elements = conditionalElement.select(TagConstants.M_ELSE);
         if(elements.isEmpty()) return null;
         if(elements.size() > 1) throw new IllegalStateException("m:if condition can only have one m:else condition. Use m:else if for multiple conditions.");
         return elements.get(0);

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
@@ -41,8 +41,8 @@ public class IterationTag extends AbstractTag {
         //     <p>Product: Darkwoods Number: 3</p>
         //</div>
 
-        Elements foreachElements = injectionResult.getDocument().getElementsByTag(ITERATION_TAG);
-        foreachElements.sort(Comparator.comparingInt(o -> o.getElementsByTag(ITERATION_TAG).size()));
+        Elements foreachElements = injectionResult.getDocument().select(ITERATION_TAG);
+        foreachElements.sort(Comparator.comparingInt(o -> o.select(ITERATION_TAG).size()));
         for (Element foreachElement : foreachElements) {
             Element clone = foreachElement.clone();
             final String collection = foreachElement.attr(ITERATION_TAG_COLLECTION_ATTR);

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/TagConstants.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/TagConstants.java
@@ -3,7 +3,7 @@ package io.getmedusa.medusa.core.injector.tag;
 public class TagConstants {
 
     //iteration - tags
-    public static final String ITERATION_TAG = "m:foreach"; //each on div
+    public static final String ITERATION_TAG = "*|foreach"; //each on div
     public static final String ITERATION_TAG_COLLECTION_ATTR = "collection";
     public static final String ITERATION_TAG_EACH_ATTR = "eachName";
 
@@ -15,14 +15,14 @@ public class TagConstants {
     public static final String TEMPLATE_TAG = "template";
 
     //text - tags
-    public static final String TEXT_TAG = "m:text";
+    public static final String TEXT_TAG = "*|text";
     public static final String TEXT_TAG_ITEM_ATTR = "item";
     public static final String M_VALUE = "m:value";
     public static final String FROM_VALUE = "from-value";
     public static final String M_ITEM = "m:item";
 
     //conditional - tags
-    public static final String CONDITIONAL_TAG = "m:if"; //each on div
+    public static final String CONDITIONAL_TAG = "*|if"; //each on div
     public static final String CONDITIONAL_TAG_CONDITION_ATTR = "item";
     public static final String CONDITIONAL_TAG_EQUALS = "eq";
     public static final String CONDITIONAL_TAG_NOT = "not";
@@ -34,8 +34,8 @@ public class TagConstants {
 
     //conditional - attributes
     public static final String M_IF = "m-if";
-    public static final String M_ELSE = "m:else";
-    public static final String M_ELSEIF = "m:elseif";
+    public static final String M_ELSE = "*|else";
+    public static final String M_ELSEIF = "*|elseif";
 
     //mclick - attributes
     public static final String M_CLICK = "m:click";

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/ValueTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/ValueTag.java
@@ -24,7 +24,7 @@ public class ValueTag extends AbstractTag {
         //becomes
         //<span from-value="counter-value">123</span>
 
-        Elements mTextTags = result.getDocument().getElementsByTag(TagConstants.TEXT_TAG);
+        Elements mTextTags = result.getDocument().select(TagConstants.TEXT_TAG);
         for (Element mTextTag : mTextTags) {
             final String item = mTextTag.attr(TagConstants.TEXT_TAG_ITEM_ATTR).trim();
             Object variableValue = getPossibleEachValue(mTextTag, item, request, variables);

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/ConditionalTagTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/ConditionalTagTest.java
@@ -10,9 +10,9 @@ import java.util.Map;
 class ConditionalTagTest extends AbstractTest {
 
     private static final String HTML_EQ_SIMPLE = """
-                    <m:if item="some-variable" eq="'a'">
+                    <med:if item="some-variable" eq="'a'">
                         <p>A</p>
-                    </m:if>
+                    </med:if>
             """;
 
     private static final String HTML_EQ_ELSE = """
@@ -26,15 +26,15 @@ class ConditionalTagTest extends AbstractTest {
             """;
 
     private static final String HTML_EQ_ELSE_IF = """
-                    <m:if item="some-variable" eq="'a'">
+                    <med:if item="some-variable" eq="'a'">
                         <p>A</p>
-                        <m:elseif item="some-other-variable" eq="1">
+                        <med:elseif item="some-other-variable" eq="1">
                             <p>B</p>
-                        </m:elseif>
-                        <m:else>
+                        </med:elseif>
+                        <med:else>
                             <p>C</p>
-                        </m:else>
-                    </m:if>
+                        </med:else>
+                    </med:if>
             """;
 
     private static final String HTML_EQ_VARIABLE = """

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/IterationTagTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/IterationTagTest.java
@@ -16,7 +16,7 @@ class IterationTagTest extends AbstractTest {
             <!DOCTYPE html>
             <html lang="en">
             <body>
-            <m:foreach collection="list-of-values"><p>Medusa</p></m:foreach>
+            <med:foreach collection="list-of-values"><p>Medusa</p></med:foreach>
             </html>""";
 
     public static final String HTML_NO_CHILD_NODE =
@@ -33,7 +33,7 @@ class IterationTagTest extends AbstractTest {
             <html lang="en">
             <body>
             <m:foreach collection="list-of-values"><p>Medusa</p></m:foreach>
-            <m:foreach collection="other-list-of-values"><p>Medusa</p></m:foreach>
+            <medusa:foreach collection="other-list-of-values"><p>Medusa</p></medusa:foreach>
             </html>""";
 
     public static final String HTML_NESTED =
@@ -43,9 +43,9 @@ class IterationTagTest extends AbstractTest {
             <body>
             <m:foreach collection="outer-list">
                 <p>outerSTART</p>
-                <m:foreach collection="inner-list">
+                <medusa:foreach collection="inner-list">
                     <p>Inner</p>
-                </m:foreach>
+                </medusa:foreach>
                 <p>outerEND</p>
             </m:foreach>
             </html>""";

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/ValueTagTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/ValueTagTest.java
@@ -8,12 +8,12 @@ import java.util.Map;
 
 class ValueTagTest extends AbstractTest {
 
-    public static final String HTML = "<p>Counter: <m:text item=\"counter-value\" /></p>";
+    public static final String HTML = "<p>Counter: <med:text item=\"counter-value\" /></p>";
     public static final String HTML_VALUE_AS_ATTRIBUTE = "<input type=\"text\" m:value=\"counter-value\" />";
     public static final String HTML_VALUE_AS_COMPLEX_ATTRIBUTE = "<input type=\"text\" m:value=\"obj.exampleValue\" />";
     public static final String HTML_WRAPPED_IN_TAG = "<p><m:text item=\"counter-value\" /></p>";
     public static final String HTML_WITH_SPACES = "<p>Counter: <m:text item=\" counter-value   \" /></p>";
-    public static final String HTML_WITH_COMPLEX_OBJECT = "<p>Counter: <m:text item=\"obj.exampleValue\" /></p>";
+    public static final String HTML_WITH_COMPLEX_OBJECT = "<p>Counter: <medusa:text item=\"obj.exampleValue\" /></p>";
 
     //public static final String HTML_ARRAY = "<p>Counter: <m:text item=\"array[0]\" /></p>";
     //public static final String HTML_MAP = "<p>Counter: <m:text item=\"map['x']\" /></p>";


### PR DESCRIPTION
Select medusa-tags without taking the namespace prefix in account.

This snippet should be parsed correctly: 
```xml
<html lang="en" xmlns:medusa="https://getmedusa.io" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="https://getmedusa.io https://raw.githubusercontent.com/medusa-ui/medusa/main/medusa-ui.xsd">
...
<medusa:text item="x" />
```
