### PR TITLE
Bug/iteration table

### DIFF
--- a/medusa-sample-implementation/pom.xml
+++ b/medusa-sample-implementation/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>io.getmedusa</groupId>
 			<artifactId>medusa-ui</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 

--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/TableIterationEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/TableIterationEventHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static io.getmedusa.medusa.core.injector.DOMChanges.of;
 
@@ -36,7 +37,14 @@ public class TableIterationEventHandler {
     }
 
     public DOMChanges add() {
-        items.add(new Item("four","vier"));
+        switch(items.size()) {
+            case 0: items.add(new Item("zero","nul")); break;
+            case 1: items.add(new Item("one","één")); break;
+            case 2: items.add(new Item("two","twee")); break;
+            case 3: items.add(new Item("three","drie")); break;
+            case 4: items.add(new Item("four","vier")); break;
+            default: items.add(new Item(UUID.randomUUID().toString(),UUID.randomUUID().toString())); break;
+        }
         return of("items", items);
     }
 

--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/TableIterationEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/TableIterationEventHandler.java
@@ -17,6 +17,7 @@ public class TableIterationEventHandler {
     List<Item> items = new ArrayList<>();
 
     public PageAttributes setupAttributes(ServerRequest request) {
+        items.clear();
         if(Boolean.valueOf(request.queryParam("load").orElse("false"))) {
             setData();
         }

--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/TableIterationEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/TableIterationEventHandler.java
@@ -1,0 +1,68 @@
+package com.sample.medusa.eventhandler.integrationtests.bug;
+
+
+import io.getmedusa.medusa.core.annotation.PageAttributes;
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.injector.DOMChanges;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.getmedusa.medusa.core.injector.DOMChanges.of;
+
+@UIEventPage(path="/test/bug/table", file = "pages/integration-tests/bug/table-iteration")
+public class TableIterationEventHandler {
+
+    List<Item> items = new ArrayList<>();
+
+    public PageAttributes setupAttributes(ServerRequest request) {
+        if(Boolean.valueOf(request.queryParam("load").orElse("false"))) {
+            setData();
+        }
+        return new PageAttributes()
+                .with("items",items);
+    }
+
+    public DOMChanges clear() {
+        items.clear();
+        return of("items", items);
+    }
+
+    public DOMChanges load() {
+        setData();
+        return of("items", items);
+    }
+
+    public DOMChanges add() {
+        items.add(new Item("four","vier"));
+        return of("items", items);
+    }
+
+    public void setData(){
+        items.clear();
+        items.add(new Item("zero","nul"));
+        items.add(new Item("one","één"));
+        items.add(new Item("two","twee"));
+        items.add(new Item("three","drie"));
+    }
+
+}
+
+class Item {
+     String name;
+     String value;
+
+    public Item(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/table-iteration.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/table-iteration.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:m="https://getmedusa.io" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://getmedusa.io https://raw.githubusercontent.com/medusa-ui/medusa/main/medusa-ui.xsd">
+<head>
+    <meta charset="UTF-8">
+    <title>Iteration problem with tables</title>
+    <link href="/stylesheet.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+    <style>
+        table, th, td {
+            border: 1px solid whitesmoke;
+            border-collapse: collapse;
+            padding: .25rem 1.25rem;
+        }
+    </style>
+</head>
+<body>
+<h1>🦑 Medusa in trouble</h1>
+<div>
+    <div>
+        <h3>Items plain</h3>
+        <ul>
+            <m:foreach collection="items" eachName="number">
+                <li>
+                    <span>
+                        <m:text item="number.name" />
+                    </span>
+                    =
+                    <span>
+                        <m:text item="number.value" />
+                    </span>
+                </li>
+            </m:foreach>
+        </ul>
+    </div>
+    <br>
+    <div>
+        <h3>Items in a table</h3>
+        <table>
+            <thead>
+              <tr><th>English</th><th>Dutch</th></tr>
+            </thead>
+            <tbody>
+                <m:foreach collection="items" eachName="nmb">
+                    <tr>
+                        <td><m:text item="nmb.name"/></td>
+                        <td><m:text item="nmb.value"/></td>
+                    </tr>
+                </m:foreach>
+            </tbody>
+        </table>
+    </div>
+</div>
+<br>
+<div>
+    <button id="clear_btn" m:click="clear()">Empty</button>
+    <button id="load_btn" m:click="load()">Load</button>
+    <button id="add_btn" m:click="add()">Add</button>
+</div>
+
+</body>
+</html>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/table-iteration.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/table-iteration.html
@@ -14,6 +14,9 @@
             border-collapse: collapse;
             padding: .25rem 1.25rem;
         }
+        .blue {
+            background-color: #040050;
+        }
     </style>
 </head>
 <body>
@@ -42,7 +45,7 @@
             <thead>
               <tr><th>English</th><th>Dutch</th></tr>
             </thead>
-            <tbody>
+            <tbody class="blue">
                 <m:foreach collection="items" eachName="nmb">
                     <tr>
                         <td class="table-item-name"><m:text item="nmb.name"/></td>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/table-iteration.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/table-iteration.html
@@ -24,11 +24,11 @@
         <ul>
             <m:foreach collection="items" eachName="number">
                 <li>
-                    <span>
+                    <span class="plain-item-name">
                         <m:text item="number.name" />
                     </span>
                     =
-                    <span>
+                    <span class="plain-item-value">
                         <m:text item="number.value" />
                     </span>
                 </li>
@@ -45,8 +45,8 @@
             <tbody>
                 <m:foreach collection="items" eachName="nmb">
                     <tr>
-                        <td><m:text item="nmb.name"/></td>
-                        <td><m:text item="nmb.value"/></td>
+                        <td class="table-item-name"><m:text item="nmb.name"/></td>
+                        <td class="table-item-value"><m:text item="nmb.value"/></td>
                     </tr>
                 </m:foreach>
             </tbody>

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/TableIterationIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/TableIterationIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.sample.medusa.bug;
+
+import com.sample.medusa.meta.AbstractSeleniumTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class TableIterationIntegrationTest extends AbstractSeleniumTest {
+
+    static List<String> itemNames= List.of("zero", "one", "two", "three");
+    static List<String> itemValues= List.of("nul", "één", "twee", "drie");
+
+    static String clearBtnId ="clear_btn";
+    static String loadBtnId ="load_btn";
+    static String addBtnId ="add_btn";
+
+    @Test
+    @DisplayName("initial loaded table-data")
+    void loadedPage(){
+        goTo("/test/bug/table?load=true");
+
+        List<String> plainItemNames = getAllTextByClass("plain-item-name");
+        List<String> tableItemNames = getAllTextByClass("table-item-name");
+        List<String> plainItemValues = getAllTextByClass("plain-item-value");
+        List<String> tableItemValues = getAllTextByClass("table-item-value");
+
+        // plain
+        Assertions.assertEquals(4, plainItemNames.size());
+        Assertions.assertEquals(itemValues, plainItemValues);
+        Assertions.assertEquals(itemNames, plainItemNames);
+
+        // table
+        Assertions.assertEquals(4, tableItemNames.size());
+        Assertions.assertEquals(itemNames, tableItemNames);
+        Assertions.assertEquals(itemValues, tableItemValues);
+    }
+
+    @Test
+    @DisplayName("initial empty table-data")
+    void emptyPage(){
+        goTo("/test/bug/table?load=false");
+
+        Assertions.assertEquals(0, getAllTextByClass("plain-item-name").size());
+        Assertions.assertEquals(0, getAllTextByClass("table-item-name").size());
+
+        Assertions.assertEquals(0, getAllTextByClass("plain-item-value").size());
+        Assertions.assertEquals(0, getAllTextByClass("table-item-value").size());
+    }
+
+    @Test
+    @DisplayName("plain-data after DOMChanges")
+    void plainDOMChanges() {
+        goTo("/test/bug/table?load=true");
+
+        //clear data
+        clickById(clearBtnId);
+        Assertions.assertEquals(0, getAllTextByClass("plain-item-name").size());
+        Assertions.assertEquals(0, getAllTextByClass("plain-item-value").size());
+
+        //load data
+        clickById(loadBtnId);
+        Assertions.assertEquals(4, getAllTextByClass("plain-item-name").size());
+        Assertions.assertEquals(4, getAllTextByClass("plain-item-value").size());
+        Assertions.assertEquals(itemNames, getAllTextByClass("plain-item-name"));
+        Assertions.assertEquals(itemValues, getAllTextByClass("plain-item-value"));
+
+        //add data
+        clickById(addBtnId);
+        Assertions.assertEquals(5, getAllTextByClass("plain-item-name").size());
+        Assertions.assertEquals(5, getAllTextByClass("plain-item-value").size());
+        Assertions.assertTrue(getAllTextByClass("plain-item-name").contains("four"));
+        Assertions.assertTrue(getAllTextByClass("plain-item-value").contains("vier"));
+    }
+
+    @Test
+    @DisplayName("table-data after DOMChanges")
+    void tableDOMChanges() {
+        goTo("/test/bug/table?load=true");
+
+        //clear data
+        clickById(clearBtnId);
+        Assertions.assertEquals(0, getAllTextByClass("table-item-name").size());
+        Assertions.assertEquals(0, getAllTextByClass("table-item-value").size());
+
+        //load data
+        clickById(loadBtnId);
+        Assertions.assertEquals(4, getAllTextByClass("table-item-name").size());
+        Assertions.assertEquals(4, getAllTextByClass("table-item-value").size());
+        Assertions.assertEquals(itemNames, getAllTextByClass("table-item-name"));
+        Assertions.assertEquals(itemValues, getAllTextByClass("table-item-value"));
+
+        //add data
+        clickById(addBtnId);
+        Assertions.assertEquals(5, getAllTextByClass("table-item-name").size());
+        Assertions.assertEquals(5, getAllTextByClass("table-item-value").size());
+        Assertions.assertTrue(getAllTextByClass("table-item-name").contains("four"));
+        Assertions.assertTrue(getAllTextByClass("table-item-value").contains("vier"));
+    }
+}

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/cache/HTMLCache.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/cache/HTMLCache.java
@@ -30,8 +30,7 @@ public class HTMLCache {
     }
 
     private Document removeAllCommentsFromHTML(String html) {
-        return Jsoup.parse(html.replaceAll("(?s)<!--.*?-->", ""),Parser.xmlParser());
-//        return Jsoup.parse(html.replaceAll("(?s)<!--.*?-->", ""));
+        return Jsoup.parse(html.replaceAll("(?s)<!--.*?-->", ""), Parser.xmlParser());
     }
 
     @Deprecated

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/cache/HTMLCache.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/cache/HTMLCache.java
@@ -2,6 +2,7 @@ package io.getmedusa.medusa.core.cache;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +30,8 @@ public class HTMLCache {
     }
 
     private Document removeAllCommentsFromHTML(String html) {
-        return Jsoup.parse(html.replaceAll("(?s)<!--.*?-->", ""));
+        return Jsoup.parse(html.replaceAll("(?s)<!--.*?-->", ""),Parser.xmlParser());
+//        return Jsoup.parse(html.replaceAll("(?s)<!--.*?-->", ""));
     }
 
     @Deprecated

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
@@ -3,8 +3,6 @@ package io.getmedusa.medusa.core.injector.tag;
 import io.getmedusa.medusa.core.injector.tag.meta.InjectionResult;
 import io.getmedusa.medusa.core.registry.EachValueRegistry;
 import io.getmedusa.medusa.core.registry.IterationRegistry;
-import io.getmedusa.medusa.core.util.ElementUtils;
-import io.getmedusa.medusa.core.util.WrapperUtils;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -12,7 +10,6 @@ import org.jsoup.nodes.Node;
 import org.jsoup.parser.Tag;
 import org.jsoup.select.Elements;
 import org.springframework.web.reactive.function.server.ServerRequest;
-import org.w3c.dom.Attr;
 
 import java.util.Collection;
 import java.util.Comparator;

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
@@ -44,21 +44,21 @@ public class IterationTag extends AbstractTag {
         //</div>
 
         Elements foreachElements = injectionResult.getDocument().select(ITERATION_TAG);
-        String parentTagName = getParentTagName(foreachElements);
-        if(parentTagName.equals("tbody") && !foreachElements.parents().isEmpty()) {
-            //remove tbody as wrapper
-            Element newParent = foreachElements.parents().get(1);
-            Element oldParent = foreachElements.parents().get(0);
-
-            while (!oldParent.childNodes().isEmpty()) {
-                newParent.appendChild(oldParent.childNodes().get(0));
-            }
-            oldParent.remove();
-
-            parentTagName = "table";
-        }
         foreachElements.sort(Comparator.comparingInt(o -> o.select(ITERATION_TAG).size()));
         for (Element foreachElement : foreachElements) {
+            String parentTagName = getParentTagName(foreachElements);
+            if(parentTagName.equals("tbody") && !foreachElements.parents().isEmpty()) {
+                //remove tbody as wrapper
+                Element newParent = foreachElements.parents().get(1);
+                Element oldParent = foreachElements.parents().get(0);
+
+                while (!oldParent.childNodes().isEmpty()) {
+                    newParent.appendChild(oldParent.childNodes().get(0));
+                }
+                oldParent.remove();
+
+                parentTagName = "table";
+            }
             Element clone = foreachElement.clone();
             final String collection = foreachElement.attr(ITERATION_TAG_COLLECTION_ATTR);
 

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
@@ -107,12 +107,21 @@ public class IterationTag extends AbstractTag {
         if(oldParent != null && oldParent.hasParent()) {
             Element newParent = oldParent.parent();
             attributes = oldParent.attributes();
+            throwErrorInCaseOfIDAttribute(foreachElement, attributes, oldParent);
             while (!oldParent.childNodes().isEmpty()) {
                 newParent.appendChild(oldParent.childNodes().get(0));
             }
             oldParent.remove();
         }
         return attributes;
+    }
+
+    private void throwErrorInCaseOfIDAttribute(Element foreachElement, Attributes attributes, Element oldParent) {
+        if(attributes.hasKeyIgnoreCase("id")) {
+            String nameOfElement = foreachElement.tag().toString() + foreachElement.attributes();
+            String nameOfWrapper = oldParent.tag().toString() + oldParent.attributes();
+            throw new IllegalStateException("Element '"+nameOfElement+"' is wrapped by a '"+nameOfWrapper+"', which would be duplicated by the foreach but contains a non-duplicatable attribute 'id'. Turn into a class or move to a parent element.");
+        }
     }
 
     private String getParentTagName(Element foreachElement) {

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/IterationTag.java
@@ -49,8 +49,9 @@ public class IterationTag extends AbstractTag {
             String parentTagName = getParentTagName(foreachElements);
             if(parentTagName.equals("tbody") && !foreachElements.parents().isEmpty()) {
                 //remove tbody as wrapper
-                Element newParent = foreachElements.parents().get(1);
                 Element oldParent = foreachElements.parents().get(0);
+                Element newParent = foreachElements.parents().get(1);
+                oldParent.attributes().forEach(a -> newParent.attr(a.getKey(), a.getValue()));
 
                 while (!oldParent.childNodes().isEmpty()) {
                     newParent.appendChild(oldParent.childNodes().get(0));

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/meta/InjectionResult.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/meta/InjectionResult.java
@@ -2,6 +2,7 @@ package io.getmedusa.medusa.core.injector.tag.meta;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +13,7 @@ public class InjectionResult {
     private List<String> scripts = new ArrayList<>();
 
     public InjectionResult(String html) {
-        this.document = Jsoup.parse(html);
+        this.document = Jsoup.parse(html,Parser.xmlParser());
     }
 
     public InjectionResult(Document html) {
@@ -41,7 +42,14 @@ public class InjectionResult {
         this.scripts = scripts;
     }
 
-/*
+    @Override
+    public String toString() {
+        return "InjectionResult{" +
+                "document=" + document +
+                '}';
+    }
+
+    /*
     public InjectionResult removeFromTitle(String regex) {
         String[] splitHTML = getHtml().split("</title>");
 

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/HTMLInjectorTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/HTMLInjectorTest.java
@@ -1,6 +1,5 @@
 package io.getmedusa.medusa.core.injector;
 
-import io.getmedusa.medusa.core.util.TestRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/IterationTagTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/IterationTagTest.java
@@ -116,6 +116,63 @@ class IterationTagTest extends AbstractTest {
             </html>
             """;
 
+    public static final String HTML_W_TABLE = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <body>
+                <table>
+                <m:foreach collection="list-of-values" eachName="myItem">
+                    <tr>
+                        <td>Each value: <m:text item="myItem" /></td>
+                    </tr>
+                </m:foreach>
+                </table>
+            </body>
+            </html>
+            """;
+
+    public static final String HTML_W_TABLE_W_TBODY = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <body>
+                <table>
+                <thead>
+                    <tr><th>Sample</th></tr>
+                </thead>
+                <tbody>
+                    <m:foreach collection="list-of-values" eachName="myItem">
+                        <tr>
+                            <td>Each value: <m:text item="myItem" /></td>
+                        </tr>
+                    </m:foreach>
+                </tbody>
+                </table>
+            </body>
+            </html>
+            """;
+
+    @Test
+    void testTableList() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("list-of-values", Arrays.asList(1,2,3,4,5));
+        String html = inject(HTML_W_TABLE, variables).html();
+        System.out.println(html);
+        Assertions.assertFalse(html.contains("m:foreach"));
+        Assertions.assertTrue(html.contains("<template") && html.contains("</template>"));
+        Assertions.assertEquals(12, countOccurrences(html, "tbody"));
+    }
+
+    @Test
+    void testTableListWithTBody() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("list-of-values", Arrays.asList(1,2,3,4,5));
+        String html = inject(HTML_W_TABLE_W_TBODY, variables).html();
+        System.out.println(html);
+        Assertions.assertFalse(html.contains("m:foreach"));
+        Assertions.assertTrue(html.contains("<template") && html.contains("</template>"));
+        Assertions.assertEquals(12, countOccurrences(html, "tbody"));
+    }
+
     @Test
     void testSingleElementList() {
         System.out.println(HTML);

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/IterationTagTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/injector/tag/IterationTagTest.java
@@ -139,7 +139,27 @@ class IterationTagTest extends AbstractTest {
                 <thead>
                     <tr><th>Sample</th></tr>
                 </thead>
-                <tbody>
+                <tbody class="red blue">
+                    <m:foreach collection="list-of-values" eachName="myItem">
+                        <tr>
+                            <td>Each value: <m:text item="myItem" /></td>
+                        </tr>
+                    </m:foreach>
+                </tbody>
+                </table>
+            </body>
+            </html>
+            """;
+
+    public static final String HTML_W_TABLE_W_TBODY_ID_EXPECT_EXCEPTION = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <body>
+                <table>
+                <thead>
+                    <tr><th>Sample</th></tr>
+                </thead>
+                <tbody id="123">
                     <m:foreach collection="list-of-values" eachName="myItem">
                         <tr>
                             <td>Each value: <m:text item="myItem" /></td>
@@ -171,6 +191,15 @@ class IterationTagTest extends AbstractTest {
         Assertions.assertFalse(html.contains("m:foreach"));
         Assertions.assertTrue(html.contains("<template") && html.contains("</template>"));
         Assertions.assertEquals(12, countOccurrences(html, "tbody"));
+    }
+
+    @Test
+    void testTableListWithTBodyAndID() {
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            Map<String, Object> variables = new HashMap<>();
+            variables.put("list-of-values", Arrays.asList(1,2,3,4,5));
+            inject(HTML_W_TABLE_W_TBODY_ID_EXPECT_EXCEPTION, variables).html();
+        });
     }
 
     @Test


### PR DESCRIPTION
Potential fix for #151

Changes:
- Using XML parser instead of JSoup's default HTML parser
- In case of a `<table>` with a foreach, we wrap the `<tr>` in a `<tbody>` instead of a `<div>`. This is valid HTML and thus browsers don't interfere with the JS logic after rendering
- In case the `<foreach>` was already wrapped in a `<tbody>`, it would generate a `tbody > tbody` chain, which is illegal HTML. As such, we remove
- In case of the above, and the `<tbody>` has any attributes, we copy the attributes over to the new parent.