### PR TITLE
empty-DOMChanges: additional test if the array is empty

### DIFF
--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -77,7 +77,7 @@ _M.log = function(responseEvent) {
 _M.eventHandler = function(e) {
     _M.debug(e);
 
-    if(!(Array.isArray(e) && (typeof e[0]['f'] !== "undefined" || typeof e[0]['t'] !== "undefined"))) {
+    if(!(Array.isArray(e) && e.length > 0 && (typeof e[0]['f'] !== "undefined" || typeof e[0]['t'] !== "undefined"))) {
         return;
     }
     


### PR DESCRIPTION
ref Issue #158 : return DOMChanges.empty(); throws a JS error

easy fix by additional testing if the array is empty before inspecting its first item.