### PR TITLE
bug-fix: #168 Parameter of a click function should not assume int

### DIFF
--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/CLickAssumeIntEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/CLickAssumeIntEventHandler.java
@@ -3,21 +3,26 @@ package com.sample.medusa.eventhandler.integrationtests.bug;
 import io.getmedusa.medusa.core.annotation.PageAttributes;
 import io.getmedusa.medusa.core.annotation.UIEventPage;
 import io.getmedusa.medusa.core.injector.DOMChanges;
+import io.getmedusa.medusa.core.util.SpelExpressionParserHelper;
 import org.springframework.web.reactive.function.server.ServerRequest;
 
 @UIEventPage(file = "pages/integration-tests/bug/click-assume-int.html", path = "/bug/click/{value}")
 public class CLickAssumeIntEventHandler {
 
     public PageAttributes setupAttributes(ServerRequest serverRequest) {
-        Long value = Long.valueOf(serverRequest.pathVariable("value"));
+        Number value =  SpelExpressionParserHelper.getValue(serverRequest.pathVariable("value"));
         return new PageAttributes()
                 .with("value", value)
-                .with("type","Long");
+                .with("type",value.getClass().getSimpleName());
+    }
+
+    public DOMChanges load(int value) {
+        return DOMChanges.of("value", value).and("type","Integer");
     }
 
     public DOMChanges load(long value) {
-        return DOMChanges.of("value", value).and("type","Long");
-    }
+            return DOMChanges.of("value", value).and("type","Long");
+        }
 
     public DOMChanges load(double value) {
         return DOMChanges.of("value", value).and("type","Double");

--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/CLickAssumeIntEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/CLickAssumeIntEventHandler.java
@@ -1,0 +1,30 @@
+package com.sample.medusa.eventhandler.integrationtests.bug;
+
+import io.getmedusa.medusa.core.annotation.PageAttributes;
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.injector.DOMChanges;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+@UIEventPage(file = "pages/integration-tests/bug/click-assume-int.html", path = "/bug/click/{value}")
+public class CLickAssumeIntEventHandler {
+
+    public PageAttributes setupAttributes(ServerRequest serverRequest) {
+        Long value = Long.valueOf(serverRequest.pathVariable("value"));
+        return new PageAttributes()
+                .with("value", value)
+                .with("type","Long");
+    }
+
+    public DOMChanges load(long value) {
+        return DOMChanges.of("value", value).and("type","Long");
+    }
+
+    public DOMChanges load(double value) {
+        return DOMChanges.of("value", value).and("type","Double");
+    }
+
+    public DOMChanges load(float value) {
+        return DOMChanges.of("value", value).and("type","Float");
+    }
+
+}

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
@@ -10,11 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
 </head>
 <body>
-    <h1>🦑 Medusa in trouble </h1>
+    <h1>🦑 Medusa in trouble?</h1>
     <p>Parameter of a click function should not assume int (vs long) </p>
     <span id="number-value"><m:text item="type"/>: <m:text item="value"/></span>
+    <br/>
+    <br/>
+    <button id="load-int" m:click="load(1648)">Load an int</button>
     <button id="load-long" m:click="load(16481396653467L)">Load a long</button>
     <button id="load-double" m:click="load(42.1223699988888d)">Load a double</button>
     <button id="load-float" m:click="load(42.12236999888888F)">Load a float</button>
+
 </body>
 </html>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
@@ -19,7 +19,7 @@
     <button id="load-long" m:click="load(16481396653467L)">Load a long</button>
     <button id="load-long2" m:click="load(16481396653468)">Load a long (as js number)</button>
     <button id="load-double" m:click="load(42.1223699988888d)">Load a double</button>
-    <button id="load-double2" m:click="load(42.1223699988889)">Load a double (as js number)</button>
+    <button id="load-double2" m:click="load(16481396653468.5)">Load a double (as js number)</button>
     <button id="load-float" m:click="load(42.12236999888888F)">Load a float</button>
 
 </body>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
@@ -17,7 +17,9 @@
     <br/>
     <button id="load-int" m:click="load(1648)">Load an int</button>
     <button id="load-long" m:click="load(16481396653467L)">Load a long</button>
+    <button id="load-long2" m:click="load(16481396653468)">Load a long (as js number)</button>
     <button id="load-double" m:click="load(42.1223699988888d)">Load a double</button>
+    <button id="load-double2" m:click="load(42.1223699988889)">Load a double (as js number)</button>
     <button id="load-float" m:click="load(42.12236999888888F)">Load a float</button>
 
 </body>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/click-assume-int.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:m="https://getmedusa.io" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://getmedusa.io https://raw.githubusercontent.com/medusa-ui/medusa/main/medusa-ui.xsd">
+<head>
+    <meta charset="UTF-8">
+    <title>Assume Int</title>
+    <link href="/stylesheet.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+</head>
+<body>
+    <h1>🦑 Medusa in trouble </h1>
+    <p>Parameter of a click function should not assume int (vs long) </p>
+    <span id="number-value"><m:text item="type"/>: <m:text item="value"/></span>
+    <button id="load-long" m:click="load(16481396653467L)">Load a long</button>
+    <button id="load-double" m:click="load(42.1223699988888d)">Load a double</button>
+    <button id="load-float" m:click="load(42.12236999888888F)">Load a float</button>
+</body>
+</html>

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
@@ -1,0 +1,29 @@
+package com.sample.medusa.bug;
+
+import com.sample.medusa.meta.AbstractSeleniumTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ClickAssumeIntIntegrationTest extends AbstractSeleniumTest {
+
+    @Test
+    void sendJavaNumber(){
+        goTo("/bug/click/42");
+        Assertions.assertEquals("Long: 42", getTextById("number-value"));
+
+        // load a number after an event
+        clickById("load-long");
+        Assertions.assertEquals("Long: 16481396653467", getTextById("number-value"));
+        clickById("load-double");
+        Assertions.assertEquals("Double: 42.1223699988888", getTextById("number-value"));
+        clickById("load-float");
+        Assertions.assertEquals("Float: 42.12237", getTextById("number-value")); // rounded
+
+        // load a long on load
+        goTo("/bug/click/16481396653467");
+        Assertions.assertEquals("Long: 16481396653467", getTextById("number-value"));
+    }
+
+}

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
@@ -11,19 +11,24 @@ public class ClickAssumeIntIntegrationTest extends AbstractSeleniumTest {
     @Test
     void sendJavaNumber(){
         goTo("/bug/click/42");
-        Assertions.assertEquals("Long: 42", getTextById("number-value"));
+        Assertions.assertEquals("Integer: 42", getTextById("number-value"));
 
         // load a number after an event
         clickById("load-long");
         Assertions.assertEquals("Long: 16481396653467", getTextById("number-value"));
+        clickById("load-int");
+        Assertions.assertEquals("Integer: 1648", getTextById("number-value"));
         clickById("load-double");
         Assertions.assertEquals("Double: 42.1223699988888", getTextById("number-value"));
         clickById("load-float");
         Assertions.assertEquals("Float: 42.12237", getTextById("number-value")); // rounded
 
         // load a long on load
-        goTo("/bug/click/16481396653467");
+        goTo("/bug/click/16481396653467L");
         Assertions.assertEquals("Long: 16481396653467", getTextById("number-value"));
+        // load a double on load
+        goTo("/bug/click/3.1415d");
+        Assertions.assertEquals("Double: 3.1415", getTextById("number-value"));
     }
 
 }

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class ClickAssumeIntIntegrationTest extends AbstractSeleniumTest {
+class ClickAssumeIntIntegrationTest extends AbstractSeleniumTest {
 
     @Test
     void sendJavaNumber(){
@@ -16,10 +16,14 @@ public class ClickAssumeIntIntegrationTest extends AbstractSeleniumTest {
         // load a number after an event
         clickById("load-long");
         Assertions.assertEquals("Long: 16481396653467", getTextById("number-value"));
+        clickById("load-long2");
+        Assertions.assertEquals("Long: 16481396653468", getTextById("number-value"));
         clickById("load-int");
         Assertions.assertEquals("Integer: 1648", getTextById("number-value"));
         clickById("load-double");
         Assertions.assertEquals("Double: 42.1223699988888", getTextById("number-value"));
+        clickById("load-double2");
+        Assertions.assertEquals("Double: 42.1223699988889", getTextById("number-value"));
         clickById("load-float");
         Assertions.assertEquals("Float: 42.12237", getTextById("number-value")); // rounded
 

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ClickAssumeIntIntegrationTest.java
@@ -23,7 +23,7 @@ class ClickAssumeIntIntegrationTest extends AbstractSeleniumTest {
         clickById("load-double");
         Assertions.assertEquals("Double: 42.1223699988888", getTextById("number-value"));
         clickById("load-double2");
-        Assertions.assertEquals("Double: 42.1223699988889", getTextById("number-value"));
+        Assertions.assertEquals("Double: 16481396653468.5", getTextById("number-value"));
         clickById("load-float");
         Assertions.assertEquals("Float: 42.12237", getTextById("number-value")); // rounded
 

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/SpelExpressionParserHelper.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/SpelExpressionParserHelper.java
@@ -7,7 +7,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 /**
  * Helper class to parse SPel-Expressions
  */
-abstract class SpelExpressionParserHelper {
+public abstract class SpelExpressionParserHelper {
 
     private static final SpelExpressionParser SPEL_EXPRESSION_PARSER = new SpelExpressionParser();
 

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -241,6 +241,7 @@ _M.injectVariablesIntoMethodExpression = function(expression, element) {
             if(parameter.length === 0) {
                 continue;
             }
+            parameter = _M.javaNumberCompatibility(parameter);
             if(!(_M.isJavaNumber(parameter) ||_M.isQuoted(parameter) || _M.isNumeric(parameter) || _M.isBoolean(parameter) )) {
                 parameter = _M.lookupVariable(parameter, element);
                 if(typeof parameter === "undefined") {
@@ -254,6 +255,15 @@ _M.injectVariablesIntoMethodExpression = function(expression, element) {
         return _M.buildMethod(methodName, parameters);
     }
 };
+
+_M.javaNumberCompatibility = function(parameter) {
+    if(_M.isNumeric(parameter)) {
+        if(parameter > 2147483647 || parameter < -2147483648) {
+            return parameter + "L";
+        }
+    }
+    return parameter;
+}
 
 _M.lookupVariable = function(parameter, element) {
     let baseParameter = parameter;

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -343,7 +343,7 @@ _M.isBoolean = function(itemToEval) {
 
 _M.isDecimal = function(x) {
     if(_M.isNumeric(x)) {
-        return x % 1 !== 0
+        return x % 1 !== 0;
     } else {
         return false;
     }

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -257,7 +257,9 @@ _M.injectVariablesIntoMethodExpression = function(expression, element) {
 };
 
 _M.javaNumberCompatibility = function(parameter) {
-    if(_M.isNumeric(parameter)) {
+    if(_M.isDecimal(parameter)) {
+        return parameter + "d";
+    } else if(_M.isNumeric(parameter)) {
         if(parameter > 2147483647 || parameter < -2147483648) {
             return parameter + "L";
         }
@@ -339,9 +341,17 @@ _M.isBoolean = function(itemToEval) {
     return "true" === itemToEval || "false" === itemToEval;
 };
 
+_M.isDecimal = function(x) {
+    if(_M.isNumeric(x)) {
+        return x % 1 !== 0
+    } else {
+        return false;
+    }
+}
+
 _M.isNumeric = function(str) {
     if (typeof str != "string") { return false; }
-    return !isNaN(str) && !isNaN(parseFloat(str));
+    return !isNaN( parseFloat( str ) ) && isFinite( str );
 }
 
 _M.isJavaNumber = function(str) {

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -339,11 +339,11 @@ _M.isJavaNumber = function(str) {
 }
 
 _M.isJavaLong = function(str) {
-    return str.match(/^\d+[l]$/ig);
+    return str.match(/^[+-]?\d+[l]$/i);
 }
 
 _M.isJavaDoubleOrFloat = function(str) {
-    return str.match(/^\d*(\.\d+)?[df]$/ig);
+    return str.match(/^[+-]?(\d+\.?\d*|\.\d+)[df]$/ig);
 }
 
 _M.injectVariablesIntoText = function(text) {

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -339,11 +339,11 @@ _M.isJavaNumber = function(str) {
 }
 
 _M.isJavaLong = function(str) {
-    return str.match(/^\d+[lL]$/);
+    return str.match(/^\d+[l]$/ig);
 }
 
 _M.isJavaDoubleOrFloat = function(str) {
-    return str.match(/^\d*(\.\d+)?[dDfF]$/);
+    return str.match(/^\d*(\.\d+)?[df]$/ig);
 }
 
 _M.injectVariablesIntoText = function(text) {

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -241,7 +241,7 @@ _M.injectVariablesIntoMethodExpression = function(expression, element) {
             if(parameter.length === 0) {
                 continue;
             }
-            if(!(_M.isQuoted(parameter) || _M.isNumeric(parameter) || _M.isBoolean(parameter))) {
+            if(!(_M.isJavaNumber(parameter) ||_M.isQuoted(parameter) || _M.isNumeric(parameter) || _M.isBoolean(parameter) )) {
                 parameter = _M.lookupVariable(parameter, element);
                 if(typeof parameter === "undefined") {
                     parameter = roughParameter;
@@ -332,6 +332,18 @@ _M.isBoolean = function(itemToEval) {
 _M.isNumeric = function(str) {
     if (typeof str != "string") { return false; }
     return !isNaN(str) && !isNaN(parseFloat(str));
+}
+
+_M.isJavaNumber = function(str) {
+   return _M.isJavaLong(str) || _M.isJavaDoubleOrFloat(str);
+}
+
+_M.isJavaLong = function(str) {
+    return str.match(/^[0-9]+[lL]$/);
+}
+
+_M.isJavaDoubleOrFloat = function(str) {
+    return str.match(/^[0-9.]+[dDfF]$/);
 }
 
 _M.injectVariablesIntoText = function(text) {
@@ -772,6 +784,7 @@ _M.parseSelfReference = function(raw, e, originElem) {
 _M.waitingForEnable = [];
 
 _M.sendEvent = function(originElem, e) {
+    _M.debug("sendEvent: " + e );
     const disableOnClick = originElem.attributes["m:disable-on-click-until"];
     if(typeof disableOnClick !== "undefined") {
         const loadingStyle = originElem.attributes["m:loading-style"];

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -339,11 +339,11 @@ _M.isJavaNumber = function(str) {
 }
 
 _M.isJavaLong = function(str) {
-    return str.match(/^[0-9]+[lL]$/);
+    return str.match(/^\d+[lL]$/);
 }
 
 _M.isJavaDoubleOrFloat = function(str) {
-    return str.match(/^[0-9.]+[dDfF]$/);
+    return str.match(/^\d*(\.\d+)?[dDfF]$/);
 }
 
 _M.injectVariablesIntoText = function(text) {

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/util/SpelExpressionParserHelperTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/util/SpelExpressionParserHelperTest.java
@@ -2,6 +2,7 @@ package io.getmedusa.medusa.core.util;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.expression.spel.SpelParseException;
 
 import java.time.Year;
 import java.util.Arrays;
@@ -16,6 +17,22 @@ class SpelExpressionParserHelperTest {
         String escaped = ExpressionEval.escape(raw);
         String result = SpelExpressionParserHelper.getValue(escaped, new Person("John", 3, new Country("Belgium")));
         Assertions.assertEquals("hello medusa 123 :: 안녕하세요세계hello world'tasdasdsasdx", result);
+    }
+
+    @Test
+    void javaNumber(){
+        Assertions.assertEquals("long", SpelExpressionParserHelper.getValue("typeOf( 1l )", new NumberType()));
+        Assertions.assertEquals("long", SpelExpressionParserHelper.getValue("typeOf( 1L )", new NumberType()));
+
+        Assertions.assertEquals("double",SpelExpressionParserHelper.getValue("typeOf( 1d )", new NumberType()));
+        Assertions.assertEquals("double",SpelExpressionParserHelper.getValue("typeOf( 1D )", new NumberType()));
+
+        Assertions.assertEquals("float",SpelExpressionParserHelper.getValue("typeOf( 1f )", new NumberType()));
+        Assertions.assertEquals("float",SpelExpressionParserHelper.getValue("typeOf( 1F )", new NumberType()));
+
+        Assertions.assertEquals("int",SpelExpressionParserHelper.getValue("typeOf( 1 )", new NumberType()));
+        Assertions.assertEquals("long",SpelExpressionParserHelper.getValue("typeOf( 123456789012345678l )", new NumberType()));
+        Assertions.assertThrowsExactly(SpelParseException.class, () -> SpelExpressionParserHelper.getValue("typeOf(123456789012345678)", new NumberType()));
     }
 
     @Test
@@ -135,4 +152,24 @@ class Country{
     public int hashCode() {
         return name.hashCode();
     }
+}
+
+class NumberType {
+
+    public String typeOf(long value){
+        return "long";
+    }
+
+    public String typeOf(double value){
+        return "double";
+    }
+
+    public String typeOf(float value){
+        return "float";
+    }
+
+    public String typeOf(int value){
+        return "int";
+    }
+
 }


### PR DESCRIPTION
The parameter of a click function should not assume int (vs  long)

- to distinguish a long from an int the SpelExpressionParser extra info about the number:
   - 1 is considered an int
   - 1l or 1L a long
   - 1d or 1D a double
   - 1f or 1F a float
- needed addition checks on the JS side, @see _M.isJavaNumber