### PR TITLE
bugfix: allow conditional if and else to have an identical content

### DIFF
--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/CombinationIterationAndConditionalHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/CombinationIterationAndConditionalHandler.java
@@ -1,0 +1,52 @@
+package com.sample.medusa.eventhandler.integrationtests;
+
+import io.getmedusa.medusa.core.annotation.PageAttributes;
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.injector.DOMChanges;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@UIEventPage(file = "pages/integration-tests/combo-if-conditional.html", path = "/test/combo-if-conditional")
+public class CombinationIterationAndConditionalHandler {
+
+    private static final String PHASE_A_DESC = "A (1, 2 / A, B / JANE, JOHN)";
+    private static final String PHASE_B_DESC = "B (3, 4 / C, D / PETER, JEANETTE)";
+
+    private List<Integer> integerList = new ArrayList<>(List.of(1, 2));
+    private List<String> stringList = new ArrayList<>(List.of("A", "B"));
+    private List<Person> personList = new ArrayList<>(List.of(new Person("1", "JANE"), new Person("2", "JOHN")));
+
+    public PageAttributes setupAttributes(){
+        return new PageAttributes()
+                .with("integers", integerList)
+                .with("strings", stringList)
+                .with("persons", personList)
+                .with("phase", PHASE_A_DESC);
+    }
+
+    //changes
+    public DOMChanges changeToPhaseB() {
+        integerList = new ArrayList<>(List.of(3, 4));
+        stringList = new ArrayList<>(List.of("C", "D"));
+        personList = new ArrayList<>(List.of(new Person("3", "PETER"), new Person("4", "JEANETTE")));
+
+        return DOMChanges.of("integers", integerList)
+                .and("strings", stringList)
+                .and("persons", personList)
+                .and("phase", PHASE_B_DESC);
+    }
+
+    public DOMChanges changeBackToPhaseA() {
+        integerList = new ArrayList<>(List.of(1, 2));
+        stringList = new ArrayList<>(List.of("A", "B"));
+        personList = new ArrayList<>(List.of(new Person("1", "JANE"), new Person("2", "JOHN")));
+
+        return DOMChanges.of("integers", integerList)
+                .and("strings", stringList)
+                .and("persons", personList)
+                .and("phase", PHASE_A_DESC);
+    }
+
+
+}

--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/PathQueryParamsEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/PathQueryParamsEventHandler.java
@@ -41,12 +41,10 @@ class PeopleService {
 class Person {
     String id;
     String name;
-    List<String> combination;
 
     public Person(String id, String name) {
         this.id = id;
         this.name = name;
-        this.combination = List.of(id, name);
     }
 
     public String getName() {
@@ -57,8 +55,5 @@ class Person {
         return id;
     }
 
-    public List<String> getCombination() {
-        return combination;
-    }
 }
 

--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/PathQueryParamsEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/PathQueryParamsEventHandler.java
@@ -41,14 +41,24 @@ class PeopleService {
 class Person {
     String id;
     String name;
+    List<String> combination;
 
     public Person(String id, String name) {
         this.id = id;
         this.name = name;
+        this.combination = List.of(id, name);
     }
 
     public String getName() {
         return name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public List<String> getCombination() {
+        return combination;
     }
 }
 

--- a/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/ConditionIdClashEventHandler.java
+++ b/medusa-sample-implementation/src/main/java/com/sample/medusa/eventhandler/integrationtests/bug/ConditionIdClashEventHandler.java
@@ -1,0 +1,33 @@
+package com.sample.medusa.eventhandler.integrationtests.bug;
+
+import io.getmedusa.medusa.core.annotation.PageAttributes;
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.injector.DOMChanges;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import java.util.List;
+
+@UIEventPage(file = "pages/integration-tests/bug/conditional-id-clash.html", path = "/test/bug/conditional-id-clash")
+public class ConditionIdClashEventHandler {
+
+    List<Expression> products = List.of(
+            new Expression("1 == 1",  true),
+            new Expression("'abc' == 'abc'",  true),
+            new Expression("true == 1",  false),
+            new Expression("false == false",  true),
+            new Expression("true != true",  false)
+    );
+
+    public PageAttributes setupAttributes(ServerRequest request){
+        return new PageAttributes()
+                .with("expressions", products)
+                .with("allTrue", request.queryParam("allTrue").orElse("false"));
+    }
+
+    public DOMChanges toggleShow(boolean show) {
+        return DOMChanges.of("allTrue", show);
+    }
+
+}
+
+record Expression(String expression, boolean result) { }

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/conditional-id-clash.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/bug/conditional-id-clash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:m="https://getmedusa.io" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://getmedusa.io https://raw.githubusercontent.com/medusa-ui/medusa/main/medusa-ui.xsd">
+<head>
+    <meta charset="UTF-8">
+    <title>Medusa conditional id clash</title>
+    <link href="/stylesheet.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+</head>
+<body>
+
+<div>
+    <m:if item="allTrue" eq="true">
+        <button id="btn-all" m:click="toggleShow(false)">Show all expressions</button>
+        <m:else>
+            <button id="btn-true" m:click="toggleShow(true)">Only show true expressions</button>
+        </m:else>
+    </m:if>
+</div>
+
+<br/>
+<div>
+    <h3>Foreach with if-else block</h3>
+    <p>Identical lines in else, cause failure?</p>
+    <m:foreach collection="expressions" eachName="expr">
+        <m:if item="allTrue" eq="true">
+            <m:if item="expr.result" eq="true">
+                <span class="expr-line"><m:text item="expr.expression"/> is <m:text item="expr.result"/></span>
+            </m:if>
+            <m:else>
+                <span class="expr-line"><m:text item="expr.expression"/> is <m:text item="expr.result"/></span>
+            </m:else>
+        </m:if>
+    </m:foreach>
+</div>
+
+</body>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/combo-if-conditional.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/combo-if-conditional.html
@@ -33,10 +33,10 @@
 <body>
 <h1>🦑 Combo iteration and conditionals</h1>
 
-<h2>Phase <m:text item="phase"/></h2>
+<h2 id="phase">Phase <m:text item="phase"/></h2>
 
-<button m:click="changeBackToPhaseA()">Change to Phase A</button> <br>
-<button m:click="changeToPhaseB()">Change to Phase B</button>
+<button id="phase-a-btn" m:click="changeBackToPhaseA()">Change to Phase A</button> <br>
+<button id="phase-b-btn" m:click="changeToPhaseB()">Change to Phase B</button>
 
 <div class="iteration-wrapper">
     <m:foreach collection="integers" eachName="integer">
@@ -133,6 +133,42 @@
         </m:if>
 
     </m:foreach>
+</div>
+
+<div class="iteration-wrapper">
+    <table>
+        <m:foreach collection="persons" eachName="person">
+            <tr>
+                <td>(each) Actual value: <m:text item="person.id"/> / <m:text item="person.name"/></td>
+                <td>
+                    <m:if item="person.id" eq="Z">
+                        <span class="conditional-bad">Final value: <m:text item="person.id"/></span>
+
+                        <m:elseif item="person.id" eq="1">
+                            <span class="conditional-ok">Final value (=1): <m:text item="person.id"/></span>
+                        </m:elseif>
+
+                        <m:else>
+                            <span class="conditional-ok">Final value (else): <m:text item="person.id"/></span>
+                        </m:else>
+                    </m:if>
+                </td>
+                <td>
+                    <m:if item="person.name" eq="Zardos">
+                        <span class="conditional-bad">Final value(2): <m:text item="person.name"/></span>
+
+                        <m:elseif item="person.name" eq="John">
+                            <span class="conditional-ok">Final value (2)(=John): <m:text item="person.name"/></span>
+                        </m:elseif>
+
+                        <m:else>
+                            <span class="conditional-ok">Final value (2)(else): <m:text item="person.name"/></span>
+                        </m:else>
+                    </m:if>
+                </td>
+            </tr>
+        </m:foreach>
+    </table>
 </div>
 
 </body>

--- a/medusa-sample-implementation/src/main/resources/pages/integration-tests/combo-if-conditional.html
+++ b/medusa-sample-implementation/src/main/resources/pages/integration-tests/combo-if-conditional.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:m="https://getmedusa.io" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://getmedusa.io https://raw.githubusercontent.com/medusa-ui/medusa/main/medusa-ui.xsd">
+<head>
+    <meta charset="UTF-8">
+    <title>Medusa combo conditional/iteration</title>
+    <link href="/stylesheet.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter&family=Merriweather&display=swap" rel="stylesheet">
+    <style>
+        div.iteration-wrapper {
+            border: 1px solid #00dcff8a;
+            margin: 1em;
+            padding: 1em;
+        }
+        .conditional-ok {
+            background: #4be57a40;
+            margin: 0;
+        }
+        .conditional-bad {
+            background: red;
+            margin: 0;
+        }
+        .debug {
+            font-family: monospace;
+            padding: 0;
+            margin: 1em 0 0;
+            opacity: 0.7;
+        }
+    </style>
+</head>
+<body>
+<h1>🦑 Combo iteration and conditionals</h1>
+
+<h2>Phase <m:text item="phase"/></h2>
+
+<button m:click="changeBackToPhaseA()">Change to Phase A</button> <br>
+<button m:click="changeToPhaseB()">Change to Phase B</button>
+
+<div class="iteration-wrapper">
+    <m:foreach collection="integers" eachName="integer">
+
+        <p class="debug">(each) Actual value: <m:text item="integer"/></p>
+
+        <m:if item="integer" eq="99">
+            <p class="conditional-bad">Final value: <m:text item="integer"/></p>
+
+            <m:elseif item="integer" eq="1">
+                <p class="conditional-ok">Final value (=1): <m:text item="integer"/></p>
+            </m:elseif>
+
+            <m:else>
+                <p class="conditional-ok">Final value (else): <m:text item="integer"/></p>
+            </m:else>
+        </m:if>
+
+        <m:if item="integer" eq="88">
+            <p class="conditional-bad">Final value (2): <m:text item="integer"/></p>
+
+            <m:elseif item="integer" eq="3">
+                <p class="conditional-ok">Final value (2)(=3): <m:text item="integer"/></p>
+            </m:elseif>
+
+            <m:else>
+                <p class="conditional-ok">Final value (2)(else): <m:text item="integer"/></p>
+            </m:else>
+        </m:if>
+
+    </m:foreach>
+</div>
+
+<div class="iteration-wrapper">
+    <m:foreach collection="strings" eachName="string">
+
+        <p class="debug">(each) Actual value: <m:text item="string"/></p>
+
+        <m:if item="string" eq="Z">
+            <p class="conditional-bad">Final value: <m:text item="string"/></p>
+
+            <m:elseif item="string" eq="A">
+                <p class="conditional-ok">Final value (=A): <m:text item="string"/></p>
+            </m:elseif>
+
+            <m:else>
+                <p class="conditional-ok">Final value (else): <m:text item="string"/></p>
+            </m:else>
+        </m:if>
+
+        <m:if item="string" eq="Q">
+            <p class="conditional-bad">Final value(2): <m:text item="string"/></p>
+
+            <m:elseif item="string" eq="B">
+                <p class="conditional-ok">Final value (2)(=B): <m:text item="string"/></p>
+            </m:elseif>
+
+            <m:else>
+                <p class="conditional-ok">Final value (2)(else): <m:text item="string"/></p>
+            </m:else>
+        </m:if>
+
+    </m:foreach>
+</div>
+
+
+<div class="iteration-wrapper">
+    <m:foreach collection="persons" eachName="person">
+
+        <p class="debug">(each) Actual value: <m:text item="person.id"/> / <m:text item="person.name"/></p>
+
+        <m:if item="person.id" eq="Z">
+            <p class="conditional-bad">Final value: <m:text item="person.id"/></p>
+
+            <m:elseif item="person.id" eq="1">
+                <p class="conditional-ok">Final value (=1): <m:text item="person.id"/></p>
+            </m:elseif>
+
+            <m:else>
+                <p class="conditional-ok">Final value (else): <m:text item="person.id"/></p>
+            </m:else>
+        </m:if>
+
+        <m:if item="person.name" eq="Zardos">
+            <p class="conditional-bad">Final value(2): <m:text item="person.name"/></p>
+
+            <m:elseif item="person.name" eq="John">
+                <p class="conditional-ok">Final value (2)(=John): <m:text item="person.name"/></p>
+            </m:elseif>
+
+            <m:else>
+                <p class="conditional-ok">Final value (2)(else): <m:text item="person.name"/></p>
+            </m:else>
+        </m:if>
+
+    </m:foreach>
+</div>
+
+</body>
+</html>

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/CombinationIterationAndConditionalHandlerTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/CombinationIterationAndConditionalHandlerTest.java
@@ -1,0 +1,27 @@
+package com.sample.medusa;
+
+import com.sample.medusa.meta.AbstractSeleniumTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CombinationIterationAndConditionalHandlerTest extends AbstractSeleniumTest {
+
+    @Test
+    void testCombinations(){
+        goTo("/test/combo-if-conditional");
+        Assertions.assertTrue(driver.getPageSource().contains("Combo iteration and conditionals"));
+
+        Assertions.assertEquals("Phase A (1, 2 / A, B / JANE, JOHN)", getTextById("phase"));
+        Assertions.assertEquals(4*4, getAllTextByClass("conditional-ok").size());
+
+        clickById("phase-b-btn");
+        Assertions.assertEquals("Phase B (3, 4 / C, D / PETER, JEANETTE)", getTextById("phase"));
+        Assertions.assertEquals(4*4, getAllTextByClass("conditional-ok").size());
+
+        clickById("phase-a-btn");
+        Assertions.assertEquals("Phase A (1, 2 / A, B / JANE, JOHN)", getTextById("phase"));
+        Assertions.assertEquals(4*4, getAllTextByClass("conditional-ok").size());
+    }
+}

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ConditionalIdClashIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ConditionalIdClashIntegrationTest.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT /*, properties = "headless=false" */)
-public class ConditionalIdClashIntegrationTest extends AbstractSeleniumTest {
+class ConditionalIdClashIntegrationTest extends AbstractSeleniumTest {
 
     public static final String CLASS_EXPR_LINE = "expr-line";
     public static final String ID_BTN_ALL = "btn-all";

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ConditionalIdClashIntegrationTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/bug/ConditionalIdClashIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.sample.medusa.bug;
+
+import com.sample.medusa.meta.AbstractSeleniumTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT /*, properties = "headless=false" */)
+public class ConditionalIdClashIntegrationTest extends AbstractSeleniumTest {
+
+    public static final String CLASS_EXPR_LINE = "expr-line";
+    public static final String ID_BTN_ALL = "btn-all";
+    public static final String ID_BTN_TRUE = "btn-true";
+    public static final List<String> expressionResults = List.of("true","true","false","true","false");
+
+    @Test
+    @DisplayName("DOMChanges: from 'all true expressions' to 'all expressions'")
+    void fromTrueToAll() {
+        goTo("/test/bug/conditional-id-clash?allTrue=true");
+        List<String> expressions = getAllTextByClass(CLASS_EXPR_LINE);
+        Assertions.assertEquals(3, expressions.size());
+        expressions
+            .forEach(
+                    line -> Assertions.assertTrue(line.endsWith("true"))
+            );
+
+        clickById(ID_BTN_ALL);
+        expressions = getAllTextByClass(CLASS_EXPR_LINE);
+        Assertions.assertEquals(5, expressions.size());
+
+        AtomicInteger index = new AtomicInteger();
+        expressions
+            .forEach(
+                    line -> Assertions.assertTrue(line.endsWith(expressionResults.get(index.getAndIncrement())))
+            );
+    }
+
+    @Test
+    @DisplayName("DOMChanges: from 'all expressions' to 'only those that are true'")
+    void fromAllToOnlyTrue() throws Exception{
+        goTo("/test/bug/conditional-id-clash?allTrue=false");
+        List<String> expressions = getAllTextByClass(CLASS_EXPR_LINE);
+        Assertions.assertEquals(5, expressions.size());
+        AtomicInteger index = new AtomicInteger();
+        expressions
+                .forEach(
+                        line -> Assertions.assertTrue(line.endsWith(expressionResults.get(index.getAndIncrement())))
+                );
+
+        clickById(ID_BTN_TRUE);
+        expressions = getAllTextByClass(CLASS_EXPR_LINE);
+        Assertions.assertEquals(3, expressions.size());
+        expressions
+                .forEach(
+                        line -> Assertions.assertTrue(line.endsWith("true"))
+                );
+
+    }
+
+}

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/meta/AbstractSeleniumTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/meta/AbstractSeleniumTest.java
@@ -16,10 +16,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-public class AbstractSeleniumTest {
+public abstract class AbstractSeleniumTest {
 
     @LocalServerPort
     private int port;

--- a/medusa-sample-implementation/src/test/java/com/sample/medusa/meta/AbstractSeleniumTest.java
+++ b/medusa-sample-implementation/src/test/java/com/sample/medusa/meta/AbstractSeleniumTest.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.server.LocalServerPort;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +50,7 @@ public class AbstractSeleniumTest {
             chromeOptions.addArguments("window-size=1400,2100");
         }
         driver = new ChromeDriver(chromeOptions);
-        driver.manage().timeouts().implicitlyWait(1, TimeUnit.SECONDS);
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(1));
         wait = new WebDriverWait(driver,1);
         javascriptExecutor = (JavascriptExecutor) driver;
         login();

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/ConditionalTag.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/injector/tag/ConditionalTag.java
@@ -16,6 +16,9 @@ import java.util.*;
 
 public class ConditionalTag extends AbstractTag {
     private static final ConditionalRegistry CONDITIONAL_REGISTRY = ConditionalRegistry.getInstance();
+    public static final String ID_SUFFIX_ELSE_IF = "e";
+    public static final String ID_SUFFIX_IF = "i";
+    public static final String ID_SUFFIX_MAIN = "m";
 
     @Override
     public InjectionResult inject(InjectionResult result, Map<String, Object> variables, ServerRequest request) {
@@ -41,14 +44,14 @@ public class ConditionalTag extends AbstractTag {
 
         for(ElseIfElement elseIfElement : elseIfElements) {
             conditions.add(elseIfElement.getCondition());
-            addIfId(elseIfElement.getElement(), elseIfElement.getCondition());
+            addIfId(elseIfElement.getElement(), ID_SUFFIX_ELSE_IF, elseIfElement.getCondition());
         }
 
         //wrapping
         WrapperUtils.wrapAndReplace(conditionalElement, "m-if-wrapper");
         final Element mainElementWrapper = wrapMainElement(mainElements, mainCondition.condition());
         final Element defaultElseWrapper = wrapDefaultElseElement(elseElement);
-        addIfId(defaultElseWrapper, oppositeOfCombinedConditions(conditions));
+        addIfId(defaultElseWrapper, ID_SUFFIX_IF, oppositeOfCombinedConditions(conditions));
 
         //visibility
         final ElseIfElement activeElseIf;
@@ -107,7 +110,7 @@ public class ConditionalTag extends AbstractTag {
 
     private Element wrapMainElement(Elements mainElements, String condition) {
         Element mainWrapper = WrapperUtils.wrap(mainElements, "m-if-main");
-        addIfId(mainWrapper, condition);
+        addIfId(mainWrapper, ID_SUFFIX_MAIN, condition);
         return mainWrapper;
     }
 
@@ -117,9 +120,9 @@ public class ConditionalTag extends AbstractTag {
         return defaultElseWrapper;
     }
 
-    private Element addIfId(Element element, String condition) {
+    private Element addIfId(Element element, String seed, String condition) {
         if(element == null) return null;
-        element.attr(TagConstants.M_IF, generateIfID(element, condition));
+        element.attr(TagConstants.M_IF, generateIfID(element, seed, condition));
         return element;
     }
 
@@ -137,13 +140,12 @@ public class ConditionalTag extends AbstractTag {
         return elements.get(0);
     }
 
-    private String generateIfID(Element element, String condition) {
-        final String ifID = IdentifierGenerator.generateIfID(element.html());
+    private String generateIfID(Element element, String suffix, String condition) {
+        final String ifID = IdentifierGenerator.generateIfID(suffix, element.html());
 
         //check if the condition here contains a reference to any of the wrapping each values
         Map<String, String> wrappingEachValues = findWrappingEachValues(element.parents());
         condition = replaceConditionValues(condition, wrappingEachValues);
-
         CONDITIONAL_REGISTRY.add(ifID, condition);
         return ifID;
     }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/IdentifierGenerator.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/util/IdentifierGenerator.java
@@ -9,15 +9,16 @@ public class IdentifierGenerator {
 
     private IdentifierGenerator() {}
 
-    //TODO: Not ideal, IDs should be unique but also reproducable
+    //TODO: Not ideal, IDs should be unique but also reproducible
     //Hash is not guaranteed unique, especially based on content (same content = same id)
 
-    public static String generateIfID(String value) {
-        final Document document = Jsoup.parse(value);
+    public static String generateIfID(String suffix, String html) {
+        final Document document = Jsoup.parse(html);
         for(Element textSpans : document.getElementsByAttribute(TagConstants.FROM_VALUE)) {
             textSpans.text("");
         }
-        return "if-" + Math.abs(document.body().html().hashCode());
+        String id = "if-" + Math.abs(document.body().html().hashCode()) + suffix;
+        return id;
     }
 
     public static String generateClassConditionalID(String value) {
@@ -27,5 +28,4 @@ public class IdentifierGenerator {
     public static String generateGenericMId(String value) {
         return "m-" + Math.abs(value.hashCode());
     }
-
 }

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -727,8 +727,9 @@ _M.handleConditionalClass = function(k) {
 };
 
 _M.evalCondition = function(condition){
-    _M.debug("Evaluating condition: " , condition);
-    return Function('"use strict";return (' + condition + ')')();
+    const result = Function('"use strict";return (' + condition + ')')();
+    _M.debug("Evaluating condition: " + condition, " result: " + result);
+    return result;
 };
 
 _M.debug = function(textToLog, fullObject) {

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -727,9 +727,8 @@ _M.handleConditionalClass = function(k) {
 };
 
 _M.evalCondition = function(condition){
-    const result = Function('"use strict";return (' + condition + ')')();
-    _M.debug("Evaluating condition: " + condition, " result: " + result);
-    return result;
+    _M.debug("Evaluating condition: " , condition);
+    return Function('"use strict";return (' + condition + ')')();;
 };
 
 _M.debug = function(textToLog, fullObject) {

--- a/medusa-ui/src/main/resources/websocket.js
+++ b/medusa-ui/src/main/resources/websocket.js
@@ -728,7 +728,7 @@ _M.handleConditionalClass = function(k) {
 
 _M.evalCondition = function(condition){
     _M.debug("Evaluating condition: " , condition);
-    return Function('"use strict";return (' + condition + ')')();;
+    return Function('"use strict";return (' + condition + ')')();
 };
 
 _M.debug = function(textToLog, fullObject) {


### PR DESCRIPTION
fixes: #185  DOMChanges did not work due to id-clash if-wrappers

Create unique ids by adding extra suffixes to the generated ids:
- an `m` for the main wrapper
- an `i`  for the if wrapper
- an `e` for the else-if wrapper
