### PR TITLE
click event #245 : allow referring to element values via #element-id

### DIFF
--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/action/MedusaOnClick.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/action/MedusaOnClick.java
@@ -2,6 +2,9 @@ package io.getmedusa.medusa.core.tags.action;
 
 import io.getmedusa.medusa.core.tags.annotation.MedusaTag;
 import io.getmedusa.medusa.core.tags.meta.JSEventAttributeProcessor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.thymeleaf.context.ITemplateContext;
 import org.thymeleaf.engine.AttributeName;
 import org.thymeleaf.model.IProcessableElementTag;
@@ -20,12 +23,39 @@ public class MedusaOnClick extends JSEventAttributeProcessor {
 
     @Override
     protected void doProcess(ITemplateContext context, IProcessableElementTag tag, AttributeName attributeName, String attributeValue, IElementTagStructureHandler structureHandler) {
-        /* TODO look how to use Thymeleaf SPeL handling */
-        Matcher matcher = CTX_VALUE_REGEX.matcher(attributeValue);
-        while (matcher.find()) {
-            String replaceValue = matcher.group(1);
-            attributeValue = attributeValue.replace(matcher.group(), context.getVariable(replaceValue).toString());
+
+        attributeValue = replaceAttributeValues(context, attributeValue);
+        attributeValue = replaceElementValues(context, attributeValue);
+
+        String formatted = attributeValue.replace("'", "\\'");
+        structureHandler.setAttribute(eventName, eventTemplate.formatted(formatted));
+    }
+
+    private String replaceElementValues(ITemplateContext context, String attributeValue) {
+        if(attributeValue.contains("#")) {
+            Matcher elementValueMatcher = CTX_ELEMENT_VALUE_REGEX.matcher(attributeValue);
+            Document document = Jsoup.parse(context.getTemplateData().getTemplate());
+            while (elementValueMatcher.find()) {
+                String id = elementValueMatcher.group(1);
+                Element element = document.getElementById(id);
+                String replaceValue = "";
+                if (element.hasAttr("value")) {
+                    replaceValue = element.val();
+                } else {
+                    replaceValue = element.text();
+                }
+                attributeValue = attributeValue.replace(elementValueMatcher.group(), replaceValue);
+            }
         }
-        structureHandler.setAttribute(eventName, eventTemplate.formatted(attributeValue.replace("'","\\'")));
+        return attributeValue;
+    }
+
+    private String replaceAttributeValues(ITemplateContext context, String attributeValue) {
+        Matcher attributeMatcher = CTX_ATTRIBUTE_VALUE_REGEX.matcher(attributeValue);
+        while (attributeMatcher.find()) {
+            String replaceValue = attributeMatcher.group(1);
+            attributeValue = attributeValue.replace(attributeMatcher.group(), context.getVariable(replaceValue).toString());
+        }
+        return attributeValue;
     }
 }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/meta/JSEventAttributeProcessor.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/meta/JSEventAttributeProcessor.java
@@ -11,7 +11,8 @@ import java.util.regex.Pattern;
 import static io.getmedusa.medusa.core.tags.annotation.MedusaTag.*;
 
 public abstract class JSEventAttributeProcessor extends AbstractAttributeTagProcessor {
-    protected static final Pattern CTX_VALUE_REGEX = Pattern.compile("\\$\\{(.*)\\}");
+    protected static final Pattern CTX_ATTRIBUTE_VALUE_REGEX = Pattern.compile("\\$\\{(.*)\\}");
+    protected static final Pattern CTX_ELEMENT_VALUE_REGEX = Pattern.compile("#(\\w*)");
     protected final String eventName;
     protected final String eventTemplate;
 

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/tags/action/MedusaOnClickTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/tags/action/MedusaOnClickTest.java
@@ -8,11 +8,13 @@ import io.getmedusa.medusa.core.tags.MedusaDialect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
 class MedusaOnClickTest {
-
+    private static final Logger logger = LoggerFactory.getLogger(MedusaOnClickTest.class);
     private Renderer renderer;
     private final Session session = buildSession();
 
@@ -27,7 +29,7 @@ class MedusaOnClickTest {
         this.renderer = new Renderer(Set.of(new MedusaDialect(Set.of(new MedusaOnClick()))), null);
     }
 
-    private final String templateHTML = """
+    private final String basicTemplateHTML = """
             <!DOCTYPE html>
             <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:m="https://www.getmedusa.io/medusa.xsd">
             <body>
@@ -37,13 +39,52 @@ class MedusaOnClickTest {
             </html>
             """;
 
+    private final String parameterTemplateHTML = """
+            <!DOCTYPE html>
+            <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:m="https://www.getmedusa.io/medusa.xsd">
+            <body>
+                <p>Value: <span th:text="${counter}"></span></p>
+                <button m:click="increment(2,'some text')">increment</button>
+            </body>
+            </html>
+            """;
+
+    private final String elementValueTemplateHTML = """
+            <!DOCTYPE html>
+            <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:m="https://www.getmedusa.io/medusa.xsd">
+            <body>
+                <span id="elm_1">42</span>
+                <input id="elm_2" value="some text">
+                <button m:click="action(#elm_1,'#elm_2')">increment</button>
+            </body>
+            </html>
+            """;
+
     @Test
-    void testRender() {
-        String template = FluxUtils.dataBufferFluxToString(renderer.render(templateHTML, session));
-        System.out.println(template);
+    void basicRenderTest() {
+        String template = FluxUtils.dataBufferFluxToString(renderer.render(basicTemplateHTML, session));
+        logger.debug(template);
         Assertions.assertFalse(template.contains("th:text="), "Thymeleaf tags should be rendered");
         Assertions.assertFalse(template.contains("m:click="), "Medusa tags should be rendered");
         Assertions.assertTrue(template.contains("onclick=\"_M.doAction(null, 'increment()')\""), "Medusa tag should be rendered with replacement JS");
+    }
+
+    @Test
+    void parameterRenderTest() {
+        String template = FluxUtils.dataBufferFluxToString(renderer.render(parameterTemplateHTML, session));
+        logger.debug(template);
+        Assertions.assertFalse(template.contains("th:text="), "Thymeleaf tags should be rendered");
+        Assertions.assertFalse(template.contains("m:click="), "Medusa tags should be rendered");
+        Assertions.assertTrue(template.contains("onclick=\"_M.doAction(null, 'increment(2,\\'some text\\')')\""), "Medusa tag should be rendered with replacement JS");
+    }
+
+    @Test
+    void elementValueRenderTest() {
+        String template = FluxUtils.dataBufferFluxToString(renderer.render(elementValueTemplateHTML, session));
+        logger.debug(template);
+        Assertions.assertFalse(template.contains("th:text="), "Thymeleaf tags should be rendered");
+        Assertions.assertFalse(template.contains("m:click="), "Medusa tags should be rendered");
+        Assertions.assertTrue(template.contains("onclick=\"_M.doAction(null, 'action(42,\\'some text\\')')\""), "Medusa tag should be able to find element values");
     }
 
 }


### PR DESCRIPTION
Replaces the reference with the tag's value attribute or when missing with the tag's text content.

example:
```html
<span id="elm_a">13</span>
<input id="elm_b" value="42">
<button m:click="someAction(#elm_a, #elm_b)">some action</button>
```
will result in

```html
<span id="elm_a">13</span>
<input id="elm_b" value="42">
<button onclick="_M.doAction(null, 'someAction(13, 42)'">some action</button>
```