### PR TITLE
Force unique callable method names

### DIFF
--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/MethodDetection.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/MethodDetection.java
@@ -4,10 +4,7 @@ import io.getmedusa.medusa.core.annotation.UIEventPage;
 import io.getmedusa.medusa.core.session.Session;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public enum MethodDetection {
 
@@ -16,22 +13,33 @@ public enum MethodDetection {
     private static final String LIST_OF_ATTRIBUTES = "java.util.List<io.getmedusa.medusa.core.attributes.Attribute>";
     private static final String VOID = "void";
 
-    private final Map<String, List<String>> methodsStartWithSession = new HashMap<>();
-    private final Map<String, List<String>> methodsEndWithSession = new HashMap<>();
+    private static String ERROR_MESSAGE = "UIEventPage '%s' has multiple callable methods named '%s' " +
+            "that could be mapped to a Medusa action. All callable methods must be unique.";
+
+    private final Map<String, Set<String>> methodsStartWithSession = new HashMap<>();
+    private final Map<String, Set<String>> methodsEndWithSession = new HashMap<>();
 
     public void consider(Object bean) {
         final UIEventPage annotation = retrieveAnnotation(bean);
+        Set<String> callableMethods = new HashSet<>();
         if(null != annotation) {
-            for(Method method : bean.getClass().getMethods()) {
-                if(method.getDeclaringClass().equals(bean.getClass()) && isMethodRelevant(annotation, method) && method.getParameterCount() > 0) {
+            Class beanClass = bean.getClass();
+            for(Method method : beanClass.getMethods()) {
+                if(method.getDeclaringClass().equals(beanClass) && isMethodRelevant(annotation, method) && method.getParameterCount() > 0) {
+                    String beanClassName = beanClass.getName();
+                    String methodName = method.getName();
+                    if(callableMethods.contains(methodName)) {
+                        throw new IllegalArgumentException(ERROR_MESSAGE.formatted(beanClassName, methodName));
+                    }
+                    callableMethods.add(methodName);
                     if(firstMethodParamIsSession(method)) {
-                        List<String> methods = methodsStartWithSession.getOrDefault(bean.getClass().getName(), new ArrayList<>());
-                        methods.add(method.getName());
-                        methodsStartWithSession.put(bean.getClass().getName(), methods);
+                        Set<String> methods = methodsStartWithSession.getOrDefault(beanClassName, new HashSet<>());
+                        methods.add(methodName);
+                        methodsStartWithSession.put(beanClassName, methods);
                     } else if(lastMethodParamIsSession(method)) {
-                        List<String> methods = methodsEndWithSession.getOrDefault(bean.getClass().getName(), new ArrayList<>());
-                        methods.add(method.getName());
-                        methodsEndWithSession.put(bean.getClass().getName(), methods);
+                        Set<String> methods = methodsEndWithSession.getOrDefault(beanClassName, new HashSet<>());
+                        methods.add(methodName);
+                        methodsEndWithSession.put(beanClassName, methods);
                     }
                 }
             }
@@ -39,11 +47,11 @@ public enum MethodDetection {
     }
 
     public boolean shouldBeginWithSession(String clazz, String method) {
-        return methodsStartWithSession.getOrDefault(clazz, new ArrayList<>()).contains(method);
+        return methodsStartWithSession.getOrDefault(clazz, new HashSet<>()).contains(method);
     }
 
     public boolean shouldEndWithSession(String clazz, String method) {
-        return methodsEndWithSession.getOrDefault(clazz, new ArrayList<>()).contains(method);
+        return methodsEndWithSession.getOrDefault(clazz, new HashSet<>()).contains(method);
     }
 
     private boolean firstMethodParamIsSession(Method method) {

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/MethodDetection.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/MethodDetection.java
@@ -13,8 +13,7 @@ public enum MethodDetection {
     private static final String LIST_OF_ATTRIBUTES = "java.util.List<io.getmedusa.medusa.core.attributes.Attribute>";
     private static final String VOID = "void";
 
-    private static String ERROR_MESSAGE = "UIEventPage '%s' has multiple callable methods named '%s' " +
-            "that could be mapped to a Medusa action. All callable methods must be unique.";
+    private static final String ERROR_MESSAGE = "'%s' has multiple callable methods named '%s' that could be mapped to a Medusa action. All callable method names must be unique.";
 
     private final Map<String, Set<String>> methodsStartWithSession = new HashMap<>();
     private final Map<String, Set<String>> methodsEndWithSession = new HashMap<>();

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
@@ -58,8 +58,8 @@ class CorrectTestController {
         return session(session, "");
     }
     /* private methods are not taken in consideration */
-    private List<Attribute> session(Session session, String something){
-        return List.of();
+    private List<Attribute> session(Session session, String data){
+        return List.of(new Attribute("something",data), new Attribute("id", session.getId()));
     }
 }
 
@@ -74,7 +74,7 @@ class BadTestController {
         return callable(session, "");
     }
 
-    private List<Attribute> callable(Session session, String something){
-        return List.of();
+    private List<Attribute> callable(Session session, String data){
+        return List.of(new Attribute("something",data), new Attribute("id", session.getId()));
     }
 }

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class MethodDetectionTest {
+class MethodDetectionTest {
     MethodDetection methodDetection = MethodDetection.INSTANCE;
 
     @Test
@@ -34,9 +34,9 @@ public class MethodDetectionTest {
                             () -> methodDetection.consider(new BadTestController()));
 
         Assertions.assertEquals(
-                "UIEventPage 'io.getmedusa.medusa.core.boot.BadTestController' " +
+                "'io.getmedusa.medusa.core.boot.BadTestController' " +
                         "has multiple callable methods named 'callable' that could be mapped to a Medusa action. " +
-                        "All callable methods must be unique.",
+                        "All callable method names must be unique.",
                 ex.getMessage());
     }
 

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
@@ -1,0 +1,80 @@
+package io.getmedusa.medusa.core.boot;
+
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.attributes.Attribute;
+import io.getmedusa.medusa.core.session.Session;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class MethodDetectionTest {
+    MethodDetection methodDetection = MethodDetection.INSTANCE;
+
+    @Test
+    void testCorrectTestController() {
+        methodDetection.consider(new CorrectTestController());
+        String beanName = CorrectTestController.class.getName();
+
+        Assertions.assertTrue(methodDetection.shouldBeginWithSession(beanName, "sessionFirst"));
+        Assertions.assertFalse(methodDetection.shouldEndWithSession(beanName, "sessionFirst"));
+
+        Assertions.assertTrue(methodDetection.shouldEndWithSession(beanName, "sessionLast"));
+        Assertions.assertFalse(methodDetection.shouldBeginWithSession(beanName, "sessionLast"));
+
+        Assertions.assertTrue(methodDetection.shouldBeginWithSession(beanName, "session"));
+        Assertions.assertFalse(methodDetection.shouldEndWithSession(beanName, "session"));
+
+    }
+
+    @Test
+    void testBadTestController() {
+        RuntimeException ex = Assertions.assertThrows(
+                            IllegalArgumentException.class,
+                            () -> methodDetection.consider(new BadTestController()));
+
+        Assertions.assertEquals(
+                "UIEventPage 'io.getmedusa.medusa.core.boot.BadTestController' " +
+                        "has multiple callable methods named 'callable' that could be mapped to a Medusa action. " +
+                        "All callable methods must be unique.",
+                ex.getMessage());
+    }
+
+}
+
+/* TestControllers */
+@UIEventPage(path = "", file = "")
+class CorrectTestController {
+
+    public List<Attribute> sessionFirst(Session session, String data){
+        return session(session, data);
+    }
+
+    public List<Attribute> sessionLast(String data, Session session ){
+        return session(session, data);
+    }
+
+    public List<Attribute> session(Session session ){
+        return session(session, "");
+    }
+    /* private methods are not taken in consideration */
+    private List<Attribute> session(Session session, String data){
+        return List.of();
+    }
+}
+
+@UIEventPage(path = "", file = "")
+class BadTestController {
+
+    public List<Attribute> callable(String data, Session session ){
+        return callable(session, data);
+    }
+
+    public List<Attribute> callable(Session session ){
+        return callable(session, "");
+    }
+
+    private List<Attribute> callable(Session session, String data){
+        return List.of();
+    }
+}

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/boot/MethodDetectionTest.java
@@ -46,19 +46,19 @@ public class MethodDetectionTest {
 @UIEventPage(path = "", file = "")
 class CorrectTestController {
 
-    public List<Attribute> sessionFirst(Session session, String data){
-        return session(session, data);
+    public List<Attribute> sessionFirst(Session session, String something){
+        return session(session, something);
     }
 
-    public List<Attribute> sessionLast(String data, Session session ){
-        return session(session, data);
+    public List<Attribute> sessionLast(String something, Session session ){
+        return session(session, something);
     }
 
     public List<Attribute> session(Session session ){
         return session(session, "");
     }
     /* private methods are not taken in consideration */
-    private List<Attribute> session(Session session, String data){
+    private List<Attribute> session(Session session, String something){
         return List.of();
     }
 }
@@ -66,15 +66,15 @@ class CorrectTestController {
 @UIEventPage(path = "", file = "")
 class BadTestController {
 
-    public List<Attribute> callable(String data, Session session ){
-        return callable(session, data);
+    public List<Attribute> callable(String something, Session session ){
+        return callable(session, something);
     }
 
     public List<Attribute> callable(Session session ){
         return callable(session, "");
     }
 
-    private List<Attribute> callable(Session session, String data){
+    private List<Attribute> callable(Session session, String something){
         return List.of();
     }
 }


### PR DESCRIPTION
An action in a page is mapped to a method in a controller purely based on the method name, ignoring the optional Session object.

Here is an example where Medusa cannot decide which is the correct method to call. 
```` java
@UIEventPage(path = "...", file = "...")
class BadTestController {

    public List<Attribute> call(String data, Session session ){
        return List.of(new Attribute("data", data));
    }

    public List<Attribute> call(Session session, String other ){
        return List.of(new Attribute("other", other));
    }
}
````
````html
<button m:click="call('hi')">What action will be called?</button>
````