### PR TITLE
Allow query-selector with string.

### DIFF
--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/attributes/Attribute.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/attributes/Attribute.java
@@ -2,6 +2,8 @@ package io.getmedusa.medusa.core.attributes;
 
 public record Attribute(String name, Object value) {
 
+    /** Attribute that indicates that loading is done. */
+    public static final Attribute LOADING_DONE = new Attribute(StandardAttributeKeys.LOADING, "loading-done");
     public Attribute() {
         this(null, null);
     }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/meta/JSEventAttributeProcessor.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/meta/JSEventAttributeProcessor.java
@@ -22,7 +22,7 @@ public abstract class JSEventAttributeProcessor extends AbstractAttributeTagProc
     private static final String BASIC_EXPRESSION = "\\{(.*?)}";
     protected static final String EVENT_TEMPLATE_M_DO_ACTION = "_M.doAction(event, " + FRAGMENT_REPLACEMENT + ", `%s`)";
     protected static final String EVENT_TEMPLATE_M_DO_ACTION_ONKEYUP = "_M.doActionOnKeyUp(%s, event, " + FRAGMENT_REPLACEMENT + ", `%s`)";
-    protected static final String SELECTOR_QUERY ="'${document.querySelector('%s').%s}'";
+    protected static final String SELECTOR_QUERY ="'${document.querySelector(`%s`).%s}'";
     protected static final String SELECTOR_THIS_REFERENCE ="'${%s.%s}'";
     protected static final String SELECTOR_DEFAULT_ATTRIBUTE ="value";
     protected static final String SELECTOR_ALLOWED_ATTRIBUTES ="accept alt checked class cols data dir disabled for href id lang list max media min multiple name open placeholder readonly rel required rows rowspan selected span target title type value width wrap";

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/sample/HelloWorldController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/sample/HelloWorldController.java
@@ -42,7 +42,7 @@ public class HelloWorldController {
                 new Attribute("people", people));
     }
 
-    public List<Attribute> increaseCounter() {
+    public List<Attribute> increaseCounter(){
         return List.of(new Attribute("counterValue", ++counter));
     }
 
@@ -85,8 +85,9 @@ public class HelloWorldController {
     }
 
     /* test m:click & m:select */
-    public List<Attribute> search(String searchFor) {
-        return List.of(new Attribute("search", searchFor));
+    public List<Attribute> search(String searchFor) throws Exception {
+        Thread.sleep(200);
+        return List.of(new Attribute("search", searchFor), Attribute.LOADING_DONE);
     }
 
 }

--- a/medusa-ui/src/main/resources/pages/hello-world.html
+++ b/medusa-ui/src/main/resources/pages/hello-world.html
@@ -87,6 +87,10 @@
             <br>
             <input type="text" m:enter="search(:{this})" />... m:enter reacts to enter
         </div>
+        <div>
+            <input name="my_data" />
+            <button m:loading-until="loading-done" m:loading-style="top" m:click="search(:{input[name='my_data']})">Search with selector :{input[name='my_data']}</button>
+        </div>
     </div>
 
     <script type="text/javascript">


### PR DESCRIPTION
fixes #334
included example and predefined loading-done attribute.

**Related branch: [rewrite-1.0.0-POC-selector-no-form](https://github.com/medusa-ui/medusa/tree/rewrite-1.0.0-POC-selector-no-form) where the selector is determined in JS and allows sending lists to the controller**