### PR TITLE
Expose reactive to controller methods

### DIFF
--- a/medusa-showcase/src/main/java/sample/getmedusa/showcase/core/model/Component.java
+++ b/medusa-showcase/src/main/java/sample/getmedusa/showcase/core/model/Component.java
@@ -14,7 +14,10 @@ public class Component {
         map.put("Controller", List.of(
                 new Component("Path variables", "path/someValue123/anotherValue432"),
                 new Component("Query parameters", "query?sample1=123someValue&sample2=543anotherValue"),
-                new Component("Headers")
+                new Component("Headers"),
+                new Component("Reactive methods", "reactive",
+                        new String[]{"/samples/reactive/page.txt"},
+                        new String[]{"/samples/reactive/controller.txt"})
         ));
 
         map.put("Button", List.of(

--- a/medusa-showcase/src/main/java/sample/getmedusa/showcase/samples/reactive/ReactiveController.java
+++ b/medusa-showcase/src/main/java/sample/getmedusa/showcase/samples/reactive/ReactiveController.java
@@ -1,0 +1,25 @@
+package sample.getmedusa.showcase.samples.reactive;
+
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.attributes.Attribute;
+import io.getmedusa.medusa.core.session.Session;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static io.getmedusa.medusa.core.attributes.Attribute.$$;
+
+@UIEventPage(path = "/detail/sample/reactive", file = "/pages/sample/reactive.html")
+public class ReactiveController {
+
+    public Mono<List<Attribute>> setupAttributes() {
+        return Mono.just(0)
+                .map(i -> $$("counter", i));
+    }
+
+    public Mono<List<Attribute>> updateCounter(int amount, Session session) {
+        int counter = session.getAttribute("counter");
+        counter += amount;
+        return Mono.just($$("counter", counter));
+    }
+}

--- a/medusa-showcase/src/main/resources/pages/sample/option-list.html
+++ b/medusa-showcase/src/main/resources/pages/sample/option-list.html
@@ -63,6 +63,7 @@
                 <select id="slc_order" m:change="order(:{this})" style="width: 156px">
                     <option th:each="drinkType: ${drinksList}"
                             th:text="${drinkType}"
+                            th:value="${drinkType}"
                             th:selected="${drinkType} == ${type}">
                         Selected Drink
                     </option>

--- a/medusa-showcase/src/main/resources/pages/sample/reactive.html
+++ b/medusa-showcase/src/main/resources/pages/sample/reactive.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:m="https://www.getmedusa.io/medusa.xsd">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Medusa - Component detail</title>
+</head>
+<body>
+
+<div id="container" m:ref="reactive">
+    <section id="hero">
+        <h1>Basic button, but reactive</h1>
+
+        <p class="lead">An example of a using Reactive classes with Medusa controllers</p>
+
+        <a id="back-to-overview" href="/">Back to overview</a>
+    </section>
+
+    <h2>Reactive method usage</h2>
+    <p>Any controller method, be it setupAttributes() or any action method, provides two different implementations.
+        You can either use a simple List<Attribute> when not using anything but a simple implementation. Or, when using reactive streams, you could use Mono<List<Attribute>> instead.</p>
+
+    <p>Behind the scenes, we're always using Reactive streams. If you use a List<Attribute>, we will wrap it with a Mono internally.</p>
+
+
+    <section class="example">
+        <span id="counter_value" class="sample-counter" th:text="${counter}"></span>
+
+        <button id="btn_update"  m:click="updateCounter(1)">Increase counter</button>
+
+        <footer th:text="${version}"></footer>
+    </section>
+
+    <section class="client">
+        <h3>Client</h3>
+        <pre><code class="language-html hljs" th:text="${clientCode[0]}"></code></pre>
+    </section>
+
+    <section class="server">
+        <h3>Server</h3>
+        <pre><code class="language-java hljs" th:text="${serverCode[0]}"></code></pre>
+    </section>
+
+
+</div>
+</body>
+</html>

--- a/medusa-showcase/src/main/resources/samples/reactive/controller.txt
+++ b/medusa-showcase/src/main/resources/samples/reactive/controller.txt
@@ -1,0 +1,23 @@
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.attributes.Attribute;
+import io.getmedusa.medusa.core.session.Session;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static io.getmedusa.medusa.core.attributes.Attribute.$$;
+
+@UIEventPage(path = "/detail/reactive", file = "/pages/reactive.html")
+public class ReactiveController {
+
+    public Mono<List<Attribute>> setupAttributes() {
+        return Mono.just(0)
+                .map(i -> $$("counter", i));
+    }
+
+    public Mono<List<Attribute>> updateCounter(int amount, Session session) {
+        int counter = session.getAttribute("counter");
+        counter += amount;
+        return Mono.just($$("counter", counter));
+    }
+}

--- a/medusa-showcase/src/main/resources/samples/reactive/page.txt
+++ b/medusa-showcase/src/main/resources/samples/reactive/page.txt
@@ -1,0 +1,4 @@
+<div th:text="${counter}"></div>
+
+<button m:click="updateCounter(1)">Increase counter</button>
+<button m:click="reset()">Reset counter</button>

--- a/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/OptionListControllerSelenideTest.java
+++ b/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/OptionListControllerSelenideTest.java
@@ -9,8 +9,7 @@ import sample.getmedusa.showcase.testing.integration.meta.SelenideIntegrationTes
 import static com.codeborne.selenide.CollectionCondition.containExactTextsCaseSensitive;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.selectedText;
-import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.Selenide.$$;
+import static com.codeborne.selenide.Selenide.*;
 import static org.openqa.selenium.By.className;
 import static org.openqa.selenium.By.id;
 

--- a/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/OptionListControllerSelenideTest.java
+++ b/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/OptionListControllerSelenideTest.java
@@ -9,8 +9,7 @@ import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.selectedText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
-import static org.openqa.selenium.By.className;
-import static org.openqa.selenium.By.id;
+import static org.openqa.selenium.By.*;
 
 public class OptionListControllerSelenideTest extends SelenideIntegrationTest {
 
@@ -46,10 +45,11 @@ public class OptionListControllerSelenideTest extends SelenideIntegrationTest {
         $(id("slc_drinks")).shouldBe(selectedText("Hot Drinks"));
 
         // and when
-        $(id("slc_order")).selectOption("Coffee");
-        $(id("slc_order")).selectOption("Hot chocolate");
+        $(id("slc_order")).selectOptionByValue("Coffee");
+        $(id("slc_order")).selectOptionByValue("Hot chocolate");
+
         $(id("slc_drinks")).selectOption("Beers");
-        $(id("slc_order")).selectOption("Dark ale");
+        $(id("slc_order")).selectOptionByValue("Dark ale");
 
         // then
         $$(className("order")).should(containExactTextsCaseSensitive("Coffee", "Hot chocolate", "Dark ale"));

--- a/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/OptionListControllerSelenideTest.java
+++ b/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/OptionListControllerSelenideTest.java
@@ -1,7 +1,9 @@
 package sample.getmedusa.showcase.testing.integration;
 
+import com.codeborne.selenide.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 import sample.getmedusa.showcase.testing.integration.meta.SelenideIntegrationTest;
 
 import static com.codeborne.selenide.CollectionCondition.containExactTextsCaseSensitive;
@@ -9,9 +11,10 @@ import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.selectedText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
-import static org.openqa.selenium.By.*;
+import static org.openqa.selenium.By.className;
+import static org.openqa.selenium.By.id;
 
-public class OptionListControllerSelenideTest extends SelenideIntegrationTest {
+class OptionListControllerSelenideTest extends SelenideIntegrationTest {
 
     @BeforeEach
     void setup(){
@@ -44,11 +47,15 @@ public class OptionListControllerSelenideTest extends SelenideIntegrationTest {
         // then
         $(id("slc_drinks")).shouldBe(selectedText("Hot Drinks"));
 
+        $(By.cssSelector("#slc_order option[value='Coffee']")).should(Condition.exist);
+
         // and when
         $(id("slc_order")).selectOptionByValue("Coffee");
         $(id("slc_order")).selectOptionByValue("Hot chocolate");
 
         $(id("slc_drinks")).selectOption("Beers");
+
+        $(By.cssSelector("#slc_order option[value='Dark ale']")).should(Condition.exist);
         $(id("slc_order")).selectOptionByValue("Dark ale");
 
         // then

--- a/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/meta/SelenideIntegrationTest.java
+++ b/medusa-showcase/src/test/java/sample/getmedusa/showcase/testing/integration/meta/SelenideIntegrationTest.java
@@ -2,6 +2,7 @@ package sample.getmedusa.showcase.testing.integration.meta;
 
 
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.junit5.TextReportExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,5 +34,6 @@ public abstract class SelenideIntegrationTest {
 
     protected void openPage(String page) {
         open("http://localhost:%d/detail/%s".formatted(port, page));
+        Selenide.sleep(500);
     }
 }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
@@ -48,12 +48,7 @@ public class UIEventPageCallWrapper {
             if(setupAttributesMethod == null) { return Mono.just(new ArrayList<>()); }
 
             if(setupAttributesMethod.getParameterCount() == 0) {
-                Object methodResponse = setupAttributesMethod.invoke(controller);
-                if(!"reactor.core.publisher.MonoCallableOnAssembly".equals(methodResponse.getClass().getName())) {
-                    return Mono.just((List<Attribute>) methodResponse);
-                } else {
-                    return (Mono<List<Attribute>>) methodResponse;
-                }
+                return returnMonoVersion(setupAttributesMethod.invoke(controller));
             }
 
             List<Object> arguments = new ArrayList<>();
@@ -64,10 +59,19 @@ public class UIEventPageCallWrapper {
                     arguments.add(session);
                 }
             }
-            return (Mono<List<Attribute>>) setupAttributesMethod.invoke(controller, arguments.toArray());
+
+            return returnMonoVersion(setupAttributesMethod.invoke(controller, arguments.toArray()));
         } catch (InvocationTargetException | IllegalAccessException e) {
             logger.error("setup attributes failed due to: " + e.getMessage(), e);
             throw new IllegalStateException("setup attributes failed", e);
+        }
+    }
+
+    private static Mono<List<Attribute>> returnMonoVersion(Object methodResponse) {
+        if(!"reactor.core.publisher.MonoCallableOnAssembly".equals(methodResponse.getClass().getName())) {
+            return Mono.just((List<Attribute>) methodResponse);
+        } else {
+            return (Mono<List<Attribute>>) methodResponse;
         }
     }
 

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
@@ -48,7 +48,12 @@ public class UIEventPageCallWrapper {
             if(setupAttributesMethod == null) { return Mono.just(new ArrayList<>()); }
 
             if(setupAttributesMethod.getParameterCount() == 0) {
-                return (Mono<List<Attribute>>) setupAttributesMethod.invoke(controller);
+                Object methodResponse = setupAttributesMethod.invoke(controller);
+                if(!"reactor.core.publisher.MonoCallableOnAssembly".equals(methodResponse.getClass().getName())) {
+                    return Mono.just((List<Attribute>) methodResponse);
+                } else {
+                    return (Mono<List<Attribute>>) methodResponse;
+                }
             }
 
             List<Object> arguments = new ArrayList<>();

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
@@ -67,8 +67,8 @@ public class UIEventPageCallWrapper {
         }
     }
 
-    private static Mono<List<Attribute>> returnMonoVersion(Object methodResponse) {
-        if(methodResponse != null && !"reactor.core.publisher.MonoCallableOnAssembly".equals(methodResponse.getClass().getName())) {
+    public static Mono<List<Attribute>> returnMonoVersion(Object methodResponse) {
+        if(methodResponse != null && !methodResponse.getClass().getName().contains("publisher.Mono")) {
             return Mono.just((List<Attribute>) methodResponse);
         } else {
             return (Mono<List<Attribute>>) methodResponse;

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapper.java
@@ -68,7 +68,7 @@ public class UIEventPageCallWrapper {
     }
 
     private static Mono<List<Attribute>> returnMonoVersion(Object methodResponse) {
-        if(!"reactor.core.publisher.MonoCallableOnAssembly".equals(methodResponse.getClass().getName())) {
+        if(methodResponse != null && !"reactor.core.publisher.MonoCallableOnAssembly".equals(methodResponse.getClass().getName())) {
             return Mono.just((List<Attribute>) methodResponse);
         } else {
             return (Mono<List<Attribute>>) methodResponse;

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/MethodDetection.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/MethodDetection.java
@@ -11,6 +11,7 @@ public enum MethodDetection {
     INSTANCE;
 
     private static final String LIST_OF_ATTRIBUTES = "java.util.List<io.getmedusa.medusa.core.attributes.Attribute>";
+    private static final String MONO_LIST_OF_ATTRIBUTES = "reactor.core.publisher.Mono<java.util.List<io.getmedusa.medusa.core.attributes.Attribute>>";
     private static final String VOID = "void";
 
     private static final String ERROR_MESSAGE = "'%s' has multiple callable methods named '%s' that could be mapped to a Medusa action. All callable method names must be unique.";
@@ -66,7 +67,7 @@ public enum MethodDetection {
         final String returnType = method.getAnnotatedReturnType().toString();
         final String methodName = method.getName();
 
-        return !methodName.equals(annotation.setup()) && (LIST_OF_ATTRIBUTES.equals(returnType) || VOID.equals(returnType));
+        return !methodName.equals(annotation.setup()) && (LIST_OF_ATTRIBUTES.equals(returnType) || VOID.equals(returnType) || MONO_LIST_OF_ATTRIBUTES.equals(returnType));
     }
 
     private UIEventPage retrieveAnnotation(Object bean) {

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
@@ -93,7 +93,7 @@ public class ActionHandler {
                         .parseExpression(expression)
                         .getValue(evaluationContext, bean);
                 //if response is not a Mono<List<Attributes>> but a List<Attributes>, just wrap it!
-                if(!"reactor.core.publisher.MonoCallableOnAssembly".equals(result.getClass().getName())) {
+                if(result != null && !"reactor.core.publisher.MonoCallableOnAssembly".equals(result.getClass().getName())) {
                     result = Mono.just(result);
                 }
             } else {

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
@@ -93,7 +93,7 @@ public class ActionHandler {
                         .parseExpression(expression)
                         .getValue(evaluationContext, bean);
                 //if response is not a Mono<List<Attributes>> but a List<Attributes>, just wrap it!
-                if(result != null && !"reactor.core.publisher.MonoCallableOnAssembly".equals(result.getClass().getName())) {
+                if(result != null && !result.getClass().getName().contains("publisher.Mono")) {
                     result = Mono.just(result);
                 }
             } else {

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
@@ -92,6 +92,10 @@ public class ActionHandler {
                 result = SPEL_EXPRESSION_PARSER
                         .parseExpression(expression)
                         .getValue(evaluationContext, bean);
+                //if response is not a Mono<List<Attributes>> but a List<Attributes>, just wrap it!
+                if(!"reactor.core.publisher.MonoCallableOnAssembly".equals(result.getClass().getName())) {
+                    result = Mono.just(result);
+                }
             } else {
                 List<ServerSideDiff> validatorViolation = new ArrayList<>();
                 for(ValidationError violation : violations) {
@@ -106,8 +110,6 @@ public class ActionHandler {
         }
         return (Mono<List<Attribute>>) result;
     }
-
-
 
     private static String handleArrayParsing(String expression) {
         Pattern pattern = Pattern.compile("\\[.*?]");

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/request/Route.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/request/Route.java
@@ -5,6 +5,7 @@ import io.getmedusa.medusa.core.attributes.Attribute;
 import io.getmedusa.medusa.core.session.Session;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.util.UriUtils;
+import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
@@ -41,7 +42,7 @@ public class Route {
         return controller.getController();
     }
 
-    public List<Attribute> getSetupAttributes(ServerRequest request, Session session) {
+    public Mono<List<Attribute>> getSetupAttributes(ServerRequest request, Session session) {
         return controller.setupAttributes(request, session);
     }
 

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
@@ -1,14 +1,18 @@
 package io.getmedusa.medusa.core.session;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.getmedusa.medusa.core.annotation.UIEventPageCallWrapper;
 import io.getmedusa.medusa.core.attributes.Attribute;
 import io.getmedusa.medusa.core.attributes.StandardAttributeKeys;
+import io.getmedusa.medusa.core.boot.RefDetection;
 import io.getmedusa.medusa.core.router.action.FileUploadMeta;
 import io.getmedusa.medusa.core.router.action.SocketSink;
 import io.getmedusa.medusa.core.router.request.Route;
 import io.getmedusa.medusa.core.util.AttributeUtils;
 import io.getmedusa.medusa.core.util.RandomUtils;
 import org.springframework.web.reactive.function.server.ServerRequest;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.*;
 
@@ -48,7 +52,14 @@ public class Session {
         this.id = RandomUtils.generateId();
         this.password = RandomUtils.generatePassword(id);
         this.hydraPath = findHydraPath(request.headers());
-        setLastParameters(route.getSetupAttributes(request, this));
+
+        route.getSetupAttributes(request, this).map(
+                s-> {
+                    setLastParameters(s);
+                    return this;
+                }
+        ).subscribe();
+
         setLastUsedTemplate(route.getTemplateHTML());
         setLastUsedHash(route.generateHash());
         getTags().put(StandardSessionTagKeys.ROUTE, request.path());
@@ -217,5 +228,17 @@ public class Session {
     public Session withLocale(String localeString) {
         this.setLocale(Locale.forLanguageTag(localeString.trim()));
         return this;
+    }
+
+    public Flux<Session> setupAttributes(String ref, boolean fragmentFallback) {
+        if(!fragmentFallback) {
+            UIEventPageCallWrapper bean = RefDetection.INSTANCE.findBeanByRef(ref);
+            if(isInitialRender()) { //TODO ? what happens 'on action'?
+                //call controller startup and use for render (add to session? separate?)
+                Mono<List<Attribute>> attributes = bean.setupAttributes(null, this);
+                return attributes.flatMapMany(a -> Flux.just(merge(a)));
+            }
+        }
+        return Flux.just(this);
     }
 }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
@@ -53,13 +53,6 @@ public class Session {
         this.password = RandomUtils.generatePassword(id);
         this.hydraPath = findHydraPath(request.headers());
 
-        route.getSetupAttributes(request, this).map(
-                s-> {
-                    setLastParameters(s);
-                    return this;
-                }
-        ).subscribe();
-
         setLastUsedTemplate(route.getTemplateHTML());
         setLastUsedHash(route.generateHash());
         getTags().put(StandardSessionTagKeys.ROUTE, request.path());

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/sample/HelloWorldController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/sample/HelloWorldController.java
@@ -7,6 +7,7 @@ import io.getmedusa.medusa.core.session.Session;
 import io.getmedusa.medusa.core.session.StandardSessionTagKeys;
 import io.getmedusa.medusa.core.session.StandardSessionTagValues;
 import org.springframework.web.reactive.function.server.ServerRequest;
+import reactor.core.publisher.Mono;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -33,13 +34,13 @@ public class HelloWorldController {
                 StandardSessionTagValues.ALL); //TODO gotta improve this somehow
     }
 
-    public List<Attribute> setupAttributes(ServerRequest serverRequest, Session session) {
+    public Mono<List<Attribute>> setupAttributes(ServerRequest serverRequest, Session session) {
         List<Person> people = new ArrayList<>();//generateListOfPeople();
-        return List.of(
+        return Mono.just(List.of(
                 //new Attribute("counterValue", Integer.parseInt(serverRequest.pathVariable("samplePathVariable"))),
                 new Attribute("counterValue", 0),
                 new Attribute("expectedTableCount", people.size()),
-                new Attribute("people", people));
+                new Attribute("people", people)));
     }
 
     public List<Attribute> increaseCounter(){

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/sample/HelloWorldController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/sample/HelloWorldController.java
@@ -43,8 +43,8 @@ public class HelloWorldController {
                 new Attribute("people", people)));
     }
 
-    public List<Attribute> increaseCounter(){
-        return List.of(new Attribute("counterValue", ++counter));
+    public Mono<List<Attribute>> increaseCounter(){
+        return Mono.just(List.of(new Attribute("counterValue", ++counter)));
     }
 
     public List<Attribute> increaseCounterWith(Integer increaseWith) {

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapperTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/annotation/UIEventPageCallWrapperTest.java
@@ -1,0 +1,19 @@
+package io.getmedusa.medusa.core.annotation;
+
+import io.getmedusa.medusa.core.attributes.Attribute;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+class UIEventPageCallWrapperTest {
+
+    @Test
+    void testToMono() {
+        List<Attribute> list = List.of(new Attribute("x", "y"));
+        Assertions.assertEquals(list, UIEventPageCallWrapper.returnMonoVersion(list).block());
+        Assertions.assertEquals(list, UIEventPageCallWrapper.returnMonoVersion(Mono.just(list)).block());
+    }
+
+}

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/router/action/ActionHandlerTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/router/action/ActionHandlerTest.java
@@ -26,7 +26,7 @@ class ActionHandlerTest {
         SocketAction socketAction = new SocketAction();
         socketAction.setAction("doActionWithoutParams()");
 
-        final Session updatedSession = actionHandler.executeAndMerge(socketAction, getRoute(), new Session());
+        final Session updatedSession = actionHandler.executeAndMerge(socketAction, getRoute(), new Session()).block();
         System.out.println(updatedSession.toLastParameterMap());
         Assertions.assertEquals(updatedSession.toLastParameterMap().get("counterValue"), 1);
     }
@@ -36,7 +36,7 @@ class ActionHandlerTest {
         SocketAction socketAction = new SocketAction();
         socketAction.setAction("doActionWithParam('zyw-123-3213', 5678)");
 
-        final Session updatedSession = actionHandler.executeAndMerge(socketAction, getRoute(), new Session());
+        final Session updatedSession = actionHandler.executeAndMerge(socketAction, getRoute(), new Session()).block();
         System.out.println(updatedSession.toLastParameterMap());
         Assertions.assertEquals(updatedSession.toLastParameterMap().get("counterValue"), 5678);
         Assertions.assertEquals(updatedSession.toLastParameterMap().get("zyw-123-3213"), "123");

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/router/action/SocketHandlerTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/router/action/SocketHandlerTest.java
@@ -18,6 +18,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ class SocketHandlerTest {
 
         Session session = new Session();
         Mockito.when(sessionMemoryRepository.retrieve(anyString(), any())).thenReturn(session);
-        Mockito.when(actionHandler.executeAndMerge(any(), any(), any())).thenReturn(session);
+        Mockito.when(actionHandler.executeAndMerge(any(), any(), any())).thenReturn(Mono.just(session));
         Mockito.when(renderer.render(anyString(), any())).thenReturn(createDataBuffer("test"));
         Mockito.when(diffEngine.calculate(nullable(String.class), nullable(String.class))).thenReturn(Set.of(new ServerSideDiff(AbstractDiff.DiffType.ADDITION)));
 

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/router/request/RouteTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/router/request/RouteTest.java
@@ -33,7 +33,7 @@ class RouteTest {
     @Test
     void testSetupAttributes() {
         Route route = new Route("/test", "", new EmbeddedSampleController());
-        List<Attribute> attributes = route.getSetupAttributes(null, null);
+        List<Attribute> attributes = route.getSetupAttributes(null, null).block();
         Assertions.assertNotNull(attributes);
         Assertions.assertEquals(1, attributes.size());
         Assertions.assertEquals(456, attributes.get(0).value());


### PR DESCRIPTION
Goal is to have the ability to either use Mono<List<Attribute>> or direct List<Attribute> for setup and controller action methods.

That way you could have reactive methods (such as a reactive DB call) lead to a page render.