### PR TITLE
Import / Export (attempt 2)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 19
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
-          java-version: 19
+          java-version: 21
           cache: maven
       - name: Build medusa-ui with tests
         working-directory: ./medusa-ui

--- a/medusa-showcase/src/main/resources/pages/detail.html
+++ b/medusa-showcase/src/main/resources/pages/detail.html
@@ -21,7 +21,7 @@
 <m:fragment ref="darkmode"></m:fragment>
 
 <section id="container">
-    <m:fragment ref="${type}"></m:fragment>
+    <m:fragment ref="${type}" imports="clientCode, serverCode, version"></m:fragment>
 </section>
 
 </body>

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/Fragment.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/Fragment.java
@@ -1,10 +1,15 @@
 package io.getmedusa.medusa.core.boot;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Fragment {
 
     private String id;
     private String service;
     private String ref;
+    private List<String> imports = new ArrayList<>();
+    private List<String> exports = new ArrayList<>();
 
     private String fallback;
 
@@ -40,12 +45,30 @@ public class Fragment {
         this.fallback = fallback;
     }
 
+    public List<String> getImports() {
+        return imports;
+    }
+
+    public void setImports(List<String> imports) {
+        this.imports = imports;
+    }
+
+    public List<String> getExports() {
+        return exports;
+    }
+
+    public void setExports(List<String> exports) {
+        this.exports = exports;
+    }
+
     public Fragment clone() {
         Fragment f = new Fragment();
         f.id = this.id;
         f.service = this.service;
         f.ref = this.ref;
         f.fallback = this.fallback;
+        f.imports = this.imports;
+        f.exports = this.exports;
         return f;
     }
 
@@ -56,6 +79,8 @@ public class Fragment {
                 ", service='" + service + '\'' +
                 ", ref='" + ref + '\'' +
                 ", fallback='" + fallback + '\'' +
+                ", imports=" + imports +
+                ", exports=" + exports +
                 '}';
     }
 }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/FragmentDetection.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/FragmentDetection.java
@@ -67,6 +67,8 @@ public enum FragmentDetection {
                 fragment.setService(orSelfAsDefault(refElement.attributes().get("service")));
                 fragment.setRef(refElement.attributes().get("ref"));
                 fragment.setId("$#FRGM-" + RandomUtils.generateId());
+                fragment.setImports(toList(refElement.attributes().get("imports")));
+                fragment.setExports(toList(refElement.attributes().get("exports")));
 
                 detectedFragments.put(fragment.getId(), fragment);
                 if(null != bean) {
@@ -85,6 +87,19 @@ public enum FragmentDetection {
             return prepFile(bean, outerHtml.replace(refElement.outerHtml(), fragment.getId()));
         }
         return html;
+    }
+
+    private List<String> toList(String importOrExport) {
+        if(null == importOrExport || importOrExport.isEmpty()) {
+            return new ArrayList<>();
+        } else {
+            String[] elements = importOrExport.split(",");
+            List<String> list = new ArrayList<>();
+            for(String elem : elements) {
+                list.add(elem.trim());
+            }
+            return list;
+        }
     }
 
     public Map<String, List<String>> getRootFragmentsUsed() {
@@ -133,6 +148,8 @@ public enum FragmentDetection {
             final Fragment clonedFragment = fragment.clone();
             clonedFragment.setService(service);
             clonedFragment.setRef(SpELUtils.parseExpression(fragment.getRef(), session));
+            clonedFragment.setImports(fragment.getImports());
+            clonedFragment.setExports(fragment.getExports());
             newFragments.add(clonedFragment);
         }
         return newFragments;

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/RefDetection.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/boot/RefDetection.java
@@ -74,7 +74,7 @@ public enum RefDetection {
         return detectedRefs.getOrDefault(key, null);
     }
 
-    public UIEventPageCallWrapper findBeanByRef(String key) { return refToBeanMap.getOrDefault(key, null); }
+    public UIEventPageCallWrapper findBeanByRef(String key) { return refToBeanMap.getOrDefault(key, new UIEventPageCallWrapper(null)); }
 
     private UIEventPage retrieveAnnotation(Object bean) {
         return bean.getClass().getAnnotation(UIEventPage.class);

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/render/Renderer.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/render/Renderer.java
@@ -117,7 +117,7 @@ public class Renderer {
 
     private static String getFragmentController(Fragment localFragment) {
         final UIEventPageCallWrapper beanByRef = RefDetection.INSTANCE.findBeanByRef(localFragment.getRef());
-        if(beanByRef != null) {
+        if(null != beanByRef && null != beanByRef.getController()) {
             return beanByRef.getController().getClass().getName();
         }
         return null;
@@ -132,14 +132,13 @@ public class Renderer {
             rawHTML = fragment.getFallback();
         }
 
-        //TODO deal with the export/imports here as well later on
-
         final String html = rawHTML;
 
-        return session.setupAttributes(ref, fragmentFallback).flatMap(s -> renderFragment(html, s).map(dataBuffer -> {
+        return session.isolateImports(fragment).setupAttributes(ref, fragmentFallback).flatMap(s -> renderFragment(html, s).map(dataBuffer -> {
             final RenderedFragment renderedFragment = new RenderedFragment();
             renderedFragment.setId(fragment.getId());
             renderedFragment.setRenderedHTML(FragmentUtils.addFragmentRefToHTML(FluxUtils.dataBufferToString(dataBuffer), ref));
+            session.cleanAndIsolateExports(fragment);
             return renderedFragment;
         }));
     }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/router/action/ActionHandler.java
@@ -43,11 +43,15 @@ public class ActionHandler {
         //find controller from cache
         Object bean = route.getController();
 
+        Session subSession = session.findSubSession(socketAction.getFragment());
+
         //execute action
-        final Mono<List<Attribute>> attributes = execute(session, socketAction, bean);
+        final Mono<List<Attribute>> attributes = execute(subSession, socketAction, bean);
 
         //merge attributes with attributes from session
-        return attributes.map(session::merge);
+        return attributes
+                .map(subSession::merge)
+                .map(x -> session);
     }
 
     private Mono<List<Attribute>> execute(Session session, SocketAction socketAction, Object bean) {

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
@@ -190,6 +190,7 @@ public class Session {
         List<Attribute> passThrough = this.lastParameters.stream()
                 .filter(p -> StandardAttributeKeys.findAllPassThroughKeys().contains(p.name()))
                 .toList();
+        lastParameters = new ArrayList<>(lastParameters);
         lastParameters.removeAll(passThrough);
         return passThrough;
     }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/session/Session.java
@@ -254,7 +254,7 @@ public class Session {
     }
 
     public Session isolateImports(Fragment fragment) {
-        Session newSession = findSubSession(fragment.getRef());
+        Session newSession = findSubSession((fragment != null) ? fragment.getRef() : null);
         Set<Attribute> newAttributes = new HashSet<>(newSession.lastParameters);
 
         if(fragment != null) {
@@ -274,6 +274,12 @@ public class Session {
                 Optional<Attribute> attribute = getLastParameters().stream()
                         .filter(a -> searchKey.equals(a.name()))
                         .findFirst();
+
+                if(!searchKey.equals(attrAlias)) {
+                    final Optional<Attribute> aliasedAttr = newAttributes.stream().filter(a -> a.name().equals(searchKey)).findFirst();
+                    aliasedAttr.ifPresent(newAttributes::remove);
+                }
+
                 attribute.ifPresent(a -> newAttributes.add(new Attribute(attrAlias, a.value())));
             }
         }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRefController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRefController.java
@@ -1,0 +1,11 @@
+package io.getmedusa.medusa.sample;
+
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+
+//ref fragment which actually imports the variable
+@UIEventPage(path = "/fragments/import-ref", file = "/pages/fragments/import-fragment-ref")
+public class ImportFragmentRefController {
+
+
+
+}

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRefController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRefController.java
@@ -1,11 +1,25 @@
 package io.getmedusa.medusa.sample;
 
 import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.attributes.Attribute;
+import io.getmedusa.medusa.core.session.Session;
+
+import java.util.List;
+
+import static io.getmedusa.medusa.core.attributes.Attribute.$$;
 
 //ref fragment which actually imports the variable
 @UIEventPage(path = "/fragments/import-ref", file = "/pages/fragments/import-fragment-ref")
 public class ImportFragmentRefController {
 
+    public List<Attribute> setupAttributes() {
+        return $$("counter", 0);
+    }
 
+    public List<Attribute> updateCounter(int amount, Session session) {
+        int counter = session.getAttribute("counter");
+        counter += amount;
+        return $$("counter", counter);
+    }
 
 }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRootController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRootController.java
@@ -5,20 +5,19 @@ package io.getmedusa.medusa.sample;
 
 import io.getmedusa.medusa.core.annotation.UIEventPage;
 import io.getmedusa.medusa.core.attributes.Attribute;
-import org.springframework.web.reactive.function.server.ServerRequest;
 
 import java.util.List;
 import java.util.Random;
+
+import static io.getmedusa.medusa.core.attributes.Attribute.$$;
 
 @UIEventPage(path = "/import-fragment", file = "/pages/import-fragment")
 public class ImportFragmentRootController {
 
     private static final Random RANDOM = new Random();
 
-    public List<Attribute> setupAttributes(ServerRequest serverRequest) {
-        return List.of(
-                new Attribute("rootValue", RANDOM.nextInt(999))
-        );
+    public List<Attribute> setupAttributes() {
+        return $$("rootValue", RANDOM.nextInt(999));
     }
 
 }

--- a/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRootController.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/sample/ImportFragmentRootController.java
@@ -1,0 +1,24 @@
+package io.getmedusa.medusa.sample;
+
+
+//parent controller that provides the value to be imported
+
+import io.getmedusa.medusa.core.annotation.UIEventPage;
+import io.getmedusa.medusa.core.attributes.Attribute;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import java.util.List;
+import java.util.Random;
+
+@UIEventPage(path = "/import-fragment", file = "/pages/import-fragment")
+public class ImportFragmentRootController {
+
+    private static final Random RANDOM = new Random();
+
+    public List<Attribute> setupAttributes(ServerRequest serverRequest) {
+        return List.of(
+                new Attribute("rootValue", RANDOM.nextInt(999))
+        );
+    }
+
+}

--- a/medusa-ui/src/main/resources/pages/fragments/import-fragment-ref.html
+++ b/medusa-ui/src/main/resources/pages/fragments/import-fragment-ref.html
@@ -7,8 +7,14 @@
 <body>
 
 <div m:ref="import-ref-fragment">
+    <section style="border: 1px solid red; margin: 1em;">
     <p>Fragment value inside of fragment: <span th:text="${rootValue}">Some numerical value goes here</span>.</p>
     <p>Fragment value inside of fragment (with alias): <span th:text="${innerValue}">Some numerical value goes here</span>.</p>
+
+        <span id="counter_value" th:text="${counter}"></span>
+
+        <button id="btn_update"  m:click="updateCounter(1)">Increase counter</button>
+    </section>
 </div>
 
 </body>

--- a/medusa-ui/src/main/resources/pages/fragments/import-fragment-ref.html
+++ b/medusa-ui/src/main/resources/pages/fragments/import-fragment-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:m="http://www.getmedusa.io">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+<div m:ref="import-ref-fragment">
+    <p>Fragment value inside of fragment: <span th:text="${rootValue}">Some numerical value goes here</span>.</p>
+    <p>Fragment value inside of fragment (with alias): <span th:text="${innerValue}">Some numerical value goes here</span>.</p>
+</div>
+
+</body>
+</html>

--- a/medusa-ui/src/main/resources/pages/import-fragment.html
+++ b/medusa-ui/src/main/resources/pages/import-fragment.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:m="http://www.getmedusa.io">
+<head>
+    <meta charset="UTF-8" />
+    <title>Import fragment</title>
+</head>
+<body>
+<section>
+
+    <p>Fragment value outside of fragment: <span th:text="${rootValue}">Some numerical value goes here</span>.</p>
+
+    <p>Fragment begins here:</p>
+
+    <m:fragment service="self" ref="import-ref-fragment" imports="rootValue, rootValue as innerValue">
+        <p style="color:red;">Fragment could not be loaded!</p>
+    </m:fragment>
+
+</section>
+</body>
+</html>

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/session/SessionTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/session/SessionTest.java
@@ -56,9 +56,10 @@ class SessionTest {
     //this can be extended with explicit imports from root/exports to root via fragment
     @Test
     void testIsolationImports() {
-        final Session session = new Session();
+        Session session = new Session();
         session.setLastRenderedHTML("hello");
         session.setLastParameters(Attribute.$$("test", 123, "test2", 456));
+
         Assertions.assertEquals(2, session.getLastParameters().size(), "Expected to start w/ 2 items");
 
         final Session fragmentSessionNoFragment = session.isolateImports(null);
@@ -67,13 +68,12 @@ class SessionTest {
                 fragmentSessionNoFragment.getLastRenderedHTML(),
                 "Excepted data like lastRenderedHTML still to be present");
 
-        Assertions.assertEquals(0,
+        Assertions.assertEquals(2,
                 fragmentSessionNoFragment.getLastParameters().size(),
-                "With no imports, expected list to be empty");
-
-        session.cleanAndIsolateExports(null);
+                "With no fragment, expected list to be same as root session, so 2");
 
         Fragment fragment = new Fragment();
+        fragment.setRef("x");
         fragment.setImports(Arrays.asList("test", "test2 as newValue"));
 
         final Session fragmentSession = session.isolateImports(fragment);
@@ -87,7 +87,6 @@ class SessionTest {
         Assertions.assertEquals(2, session.getLastParameters().size(), "Expected to end w/ 2 items");
         Assertions.assertTrue(session.getLastParameters().stream().anyMatch(a -> "test".equals(a.name())), "Expected one of the attributes to be 'test'");
         Assertions.assertTrue(session.getLastParameters().stream().anyMatch(a -> "test2".equals(a.name())), "Expected one of the attributes to be 'test2'");
-
     }
 
     //session.cleanAndIsolateExports(fragment);

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/core/session/SessionTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/core/session/SessionTest.java
@@ -1,10 +1,12 @@
 package io.getmedusa.medusa.core.session;
 
 import io.getmedusa.medusa.core.attributes.Attribute;
+import io.getmedusa.medusa.core.boot.Fragment;
 import io.getmedusa.medusa.core.util.JSONUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,5 +50,47 @@ class SessionTest {
         session = session.withLocale("it");
         Assertions.assertEquals(Locale.ITALIAN, session.getLocale());
     }
+
+    //this test does the code for import/exports
+    //without any, we would expect a brand new session
+    //this can be extended with explicit imports from root/exports to root via fragment
+    @Test
+    void testIsolationImports() {
+        final Session session = new Session();
+        session.setLastRenderedHTML("hello");
+        session.setLastParameters(Attribute.$$("test", 123, "test2", 456));
+        Assertions.assertEquals(2, session.getLastParameters().size(), "Expected to start w/ 2 items");
+
+        final Session fragmentSessionNoFragment = session.isolateImports(null);
+
+        Assertions.assertEquals("hello",
+                fragmentSessionNoFragment.getLastRenderedHTML(),
+                "Excepted data like lastRenderedHTML still to be present");
+
+        Assertions.assertEquals(0,
+                fragmentSessionNoFragment.getLastParameters().size(),
+                "With no imports, expected list to be empty");
+
+        session.cleanAndIsolateExports(null);
+
+        Fragment fragment = new Fragment();
+        fragment.setImports(Arrays.asList("test", "test2 as newValue"));
+
+        final Session fragmentSession = session.isolateImports(fragment);
+
+        Assertions.assertEquals(2, fragmentSession.getLastParameters().size(), "With imports, expected 2 items");
+        Assertions.assertTrue(fragmentSession.getLastParameters().stream().anyMatch(a -> "test".equals(a.name())), "Expected one of the attributes to be 'test'");
+        Assertions.assertTrue(fragmentSession.getLastParameters().stream().anyMatch(a -> "newValue".equals(a.name())), "Expected one of the attributes to be 'newValue', the alias");
+
+
+        session.cleanAndIsolateExports(fragment);
+        Assertions.assertEquals(2, session.getLastParameters().size(), "Expected to end w/ 2 items");
+        Assertions.assertTrue(session.getLastParameters().stream().anyMatch(a -> "test".equals(a.name())), "Expected one of the attributes to be 'test'");
+        Assertions.assertTrue(session.getLastParameters().stream().anyMatch(a -> "test2".equals(a.name())), "Expected one of the attributes to be 'test2'");
+
+    }
+
+    //session.cleanAndIsolateExports(fragment);
+
 
 }


### PR DESCRIPTION
See https://medusa-ui.github.io/documentation/docs/internals/hydra-flow#fragments

<m:fragment service="orderService" ref="checkout" exports="postalZipCode, addressLine2 as address" imports="dob, countryOrigin as country">

Fallback info

</m:fragment>

So there are two layers a variable can live:

- On the parent page
- Inside the fragment

An export brings an variable from within the fragment to the parent page

An import brings a variable from the parent page into the fragment

Both could be done via an alias, where the name changes as it crosses the layer boundary

Can this work dynamically at all? IE a value from an input in parent determines the outcome of something in the fragment? Unlikely since this is server rendered, but a potentially common usecase, no? Would that matter, because the JS would be cross field anyway, right? Worth writing out as an example, either way.

So components I want to see:

- Fragment with import: http://localhost:8080/import-fragment
- Fragment with export: TODO
- Fragment with JS interaction across boundaries: TODO

- Progress:
    - The fragment now contains import/export data
    - Next ‘merge’ it somewhere, but where is good? Does it different for import vs export? The session, perhaps?
        - The session sounds good, but does it always stay on the session? IE when you render something … only the imports relevant to the current fragment should be imported
        - So first thing I need to do is ‘break’ it, create a new session when rendering a fragment: DONE
        - Then I need to append to that new session from the main session in case there's an import: DONE