### PR TITLE
refer to the controller in page

### DIFF
--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/attribute/MedusaControllerAttribute.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/tags/attribute/MedusaControllerAttribute.java
@@ -1,0 +1,28 @@
+package io.getmedusa.medusa.core.tags.attribute;
+
+import io.getmedusa.medusa.core.tags.annotation.MedusaTag;
+import io.getmedusa.medusa.core.tags.meta.MedusaAttributeProcessor;
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.engine.AttributeName;
+import org.thymeleaf.model.IProcessableElementTag;
+import org.thymeleaf.processor.element.IElementTagStructureHandler;
+
+/**
+ * Reference to the controller.
+ * Referencing the controller is optional and does not do anything, it just is linking the page with the controller.
+ * This reference will not be display in the resulting HTML.
+ */
+@MedusaTag
+public class MedusaControllerAttribute extends MedusaAttributeProcessor {
+
+    public static final String ATTRIBUTE_NAME = "controller";
+
+    public MedusaControllerAttribute(){
+         super(ATTRIBUTE_NAME);
+     }
+
+    @Override
+    protected void doProcess(ITemplateContext context, IProcessableElementTag tag, AttributeName attributeName, String attributeValue, IElementTagStructureHandler structureHandler) {
+        // nothing to do just remove m:controller
+    }
+}

--- a/medusa-ui/src/main/resources/META-INF/org.getmedusa.dialect/MedusaDialect.xml
+++ b/medusa-ui/src/main/resources/META-INF/org.getmedusa.dialect/MedusaDialect.xml
@@ -9,17 +9,17 @@
 
     <attribute-processor name="click"         class="io.getmedusa.medusa.core.tags.action.MedusaOnClick"/>
     <attribute-processor name="change"        class="io.getmedusa.medusa.core.tags.action.MedusaOnChange"/>
+    <attribute-processor name="controller"    class="io.getmedusa.medusa.core.tags.attribute.MedusaControllerAttribute"/>
     <attribute-processor name="enter"         class="io.getmedusa.medusa.core.tags.action.MedusaOnEnter"/>
     <attribute-processor name="keyup"         class="io.getmedusa.medusa.core.tags.action.MedusaOnKeyUp"/>
-    <attribute-processor name="click"         class="io.getmedusa.medusa.core.tags.action.MedusaOnSelect"/>
-    <attribute-processor name="select"        class="io.getmedusa.medusa.core.tags.action.MedusaOnSelect"/>
-    <attribute-processor name="upload"        class="io.getmedusa.medusa.core.tags.action.MedusaUpload"/>
-    <attribute-processor name="validate"      class="io.getmedusa.medusa.core.tags.action.MedusaValidate"/>
-    <attribute-processor name="ref"           class="io.getmedusa.medusa.core.tags.attribute.MedusaRefAttribute"/>
     <attribute-processor name="loading-until" class="io.getmedusa.medusa.core.tags.attribute.MedusaLoadingAttribute"/>
     <attribute-processor name="loading-style" class="io.getmedusa.medusa.core.tags.attribute.MedusaLoadingAttribute">
         <restrictions values="top full bottom"/> <!-- does not work -->
     </attribute-processor>
+    <attribute-processor name="ref"           class="io.getmedusa.medusa.core.tags.attribute.MedusaRefAttribute"/>
+    <attribute-processor name="select"        class="io.getmedusa.medusa.core.tags.action.MedusaOnSelect"/>
+    <attribute-processor name="upload"        class="io.getmedusa.medusa.core.tags.action.MedusaUpload"/>
+    <attribute-processor name="validate"      class="io.getmedusa.medusa.core.tags.action.MedusaValidate"/>
 
     <element-processor name="fragment" class="io.getmedusa.medusa.core.tags.attribute.MedusaFragmentAttribute" />
 </dialect>

--- a/medusa-ui/src/main/resources/pages/clicks.html
+++ b/medusa-ui/src/main/resources/pages/clicks.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <title>Clicks</title>
 </head>
-<body>
+<body m:controller="io.getmedusa.medusa.sample.ClickController">
 <h1>Clicks</h1>
     <p>
         <span>Press a button to see the executed action. </span>
@@ -22,6 +22,6 @@
     <div><button m:click="actionNumber(${number})">actionNumber(${number})</button></div>
     <div><button m:click="actionString('${one.name}')">actionString('${one.name}')</button></div>
     <div><button m:click="actionNumber(${one.target})">actionNumber(${one.number})</button></div>
-    <div><button m:click="actionNumberString(${one.target}, '${two.target.name}')">actionNumberString(${one.target}, '${two.target.name}')</button></div>
+    <div><button m:click="actionNumberString(${one.target},'${two.target.name}')">actionNumberString(${one.target}, '${two.target.name}')</button></div>
 </body>
 </html>

--- a/medusa-ui/src/test/java/io/getmedusa/medusa/tags/ControllerTagTest.java
+++ b/medusa-ui/src/test/java/io/getmedusa/medusa/tags/ControllerTagTest.java
@@ -1,0 +1,46 @@
+package io.getmedusa.medusa.tags;
+
+import io.getmedusa.medusa.core.render.Renderer;
+import io.getmedusa.medusa.core.session.Session;
+import io.getmedusa.medusa.core.tags.MedusaDialect;
+import io.getmedusa.medusa.core.tags.attribute.MedusaControllerAttribute;
+import io.getmedusa.medusa.core.util.FluxUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+import static io.getmedusa.medusa.core.attributes.Attribute.$$;
+
+public class ControllerTagTest {
+    private static final Logger logger = LoggerFactory.getLogger(ControllerTagTest.class);
+    final Renderer renderer = new Renderer(Set.of(new MedusaDialect(Set.of(new MedusaControllerAttribute()))), null,  "self", null, null);
+
+    @Test
+    void basicRenderTest() {
+        // given
+        String basicTemplateHTML = """
+                <!DOCTYPE html>
+                <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:m="http://www.getmedusa.io">
+                <body m:controller="example.controller.MyController">
+                    <p th:text="${message}">Hello World.</p>
+                </body>
+                </html>
+                """;
+        Session session = new Session();
+        session.merge($$("message","Hallo Medusa!"));
+
+        // when
+        String template = FluxUtils.dataBufferFluxToString(renderer.render(basicTemplateHTML, session));
+        logger.debug(template);
+
+        // then
+        Assertions.assertTrue(template.contains("<p>Hallo Medusa!</p>"),"Tags should be resolved");
+
+        // and
+        Assertions.assertFalse(template.contains("m:controller"), "Medusa tags should be removed");
+        Assertions.assertFalse(template.contains("example.controller.MyController"), "Reference to controller should not be included");;
+    }
+}


### PR DESCRIPTION
Allow a reference to the controller inside a page.

This reference is only intended to help the developer, and does not affect the final generated HTML, it is simply removed.