### PR TITLE
Fix INVALID_CHARACTER_ERR in Jsoup Script Tag Handling (diff-engine latest snapshot)

### DIFF
--- a/medusa-ui/src/main/java/io/getmedusa/medusa/core/render/Renderer.java
+++ b/medusa-ui/src/main/java/io/getmedusa/medusa/core/render/Renderer.java
@@ -38,7 +38,7 @@ import static org.springframework.http.MediaType.TEXT_HTML;
 @Component
 public class Renderer {
 
-    public static final String CDATA_START = "//<![CDATA[ ";
+    public static final String CDATA_START = "//<![CDATA[";
     public static final String CDATA_END = "//]]>";
     protected static final String END_OF_BODY = "</body>";
 


### PR DESCRIPTION
This pull request addresses issue #652 where integration tests were failing with a `reactor.core.Exceptions$ErrorCallbackNotImplemented` exception due to an underlying `org.w3c.dom.DOMException: INVALID_CHARACTER_ERR`.

**Root Cause:**

The issue was caused by a mismatch in handling script tag escaping between Jsoup (newer version) and our Renderer implementation. Jsoup uses `//<![CDATA[\n\r\n` (with newlines) for escaping, while our Renderer checked for `//<![CDATA[ ` (with a space instead of a newline).

**Specific to diff-engine (latest snapshot):**

It's important to note that this incompatibility only surfaced when using the latest snapshot version of the diff-engine library.

**Proposed Fix:**

This pull request fixes the issue by removing the extra space character in the Renderer check. This ensures compatibility with Jsoup's escaping behavior for the diff-engine latest snapshot version.

**Changes:**

Modified [CDATA_START](https://github.com/medusa-ui/medusa/blob/6c5fb33407e091b3d54e020e0b4f02dadfcaa3fc/medusa-ui/src/main/java/io/getmedusa/medusa/core/render/Renderer.java#L41): removed the extra space character.

**Testing:**

Integration tests have been re-run to verify the fix.

**Request for Review:**

Please review the changes and provide feedback.