### PR TITLE
Codacy Static Code Analysis #718 #719 conflict

### DIFF
--- a/medusa-ui/pom.xml
+++ b/medusa-ui/pom.xml
@@ -32,7 +32,7 @@
 		<java-jwt-auth0.version>4.4.0</java-jwt-auth0.version>
 		<caffeine.version>3.1.8</caffeine.version>
 		<!-- plugin version -->
-		<openrewrite.version>5.38.1</openrewrite.version>
+		<openrewrite.version>5.39.0</openrewrite.version>
 		<gpg.version>3.2.4</gpg.version>
 		<nexus-staging.version>1.7.0</nexus-staging.version>
 	</properties>


### PR DESCRIPTION
Dependabot update plugin versions:

- Bumps `rewrite-maven-plugin` from `5.38.1` to `5.39.0`.
#718

- Bumps `maven-gpg-plugin` from `3.2.4` to `3.2.5`.
#719 